### PR TITLE
fix: Update openapi parser errors

### DIFF
--- a/src/assets/api/crowdin/file-based.yml
+++ b/src/assets/api/crowdin/file-based.yml
@@ -1199,6 +1199,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/MethodNotAllowedExceptionResource'
   '/users/{userId}/ai/reports':
+    parameters:
+      - $ref: '#/components/parameters/UserId'
     post:
       tags:
         - AI
@@ -9080,6 +9082,8 @@ paths:
           description: 'User Security Log Id. Get via [List User Security Logs](#operation/api.users.security-logs.getMany)'
           required: true
           example: 1
+          schema:
+            type: integer
       responses:
         '200':
           description: 'User Security Log Data'

--- a/src/assets/api/crowdin/string-based.yml
+++ b/src/assets/api/crowdin/string-based.yml
@@ -1199,6 +1199,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/MethodNotAllowedExceptionResource'
   '/users/{userId}/ai/reports':
+    parameters:
+      - $ref: '#/components/parameters/UserId'
     post:
       tags:
         - AI

--- a/src/assets/api/enterprise/file-based.yml
+++ b/src/assets/api/enterprise/file-based.yml
@@ -10172,6 +10172,8 @@ paths:
           description: 'User Security Log Id. Get via [List User Security Logs](#operation/api.users.security-logs.getMany)'
           required: true
           example: 1
+          schema:
+            type: integer
       responses:
         '200':
           description: 'User Security Log Data'

--- a/src/assets/api/enterprise/string-based.yml
+++ b/src/assets/api/enterprise/string-based.yml
@@ -9437,6 +9437,8 @@ paths:
           description: 'User Security Log Id. Get via [List User Security Logs](#operation/api.users.security-logs.getMany)'
           required: true
           example: 1
+          schema:
+            type: integer
       responses:
         '200':
           description: 'User Security Log Data'


### PR DESCRIPTION
Hello!
I noticed couple errors in parsing of openapi specs and I tried to fix it with this PR. I am not sure that this files are single source of truth (but it looks like that).

Fixed errors:
* `paths.'/users/{userId}/ai/reports'. Declared path parameter userId needs to be defined as a path parameter in path or operation level`
*  `attribute paths.'/users/{userId}/security-logs/{securityLogId}'(get).parameters.[securityLogId].content is missing`

