### PR TITLE
fix: OG image path

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -19,7 +19,7 @@ const hideHeader = Astro.locals.starlightRoute.entry?.data?.hideHeader || false;
 const metaRobots = Astro.locals.starlightRoute.entry?.data?.metaRobots || undefined;
 
 const ogImageUrl = new URL(
-    `/og/${Astro.locals.starlightRoute.id.replace(/\.\w+$/, '.png')}`,
+    `/og/${Astro.locals.starlightRoute.entry.id || 'index'}.png`,
     Astro.site,
 );
 


### PR DESCRIPTION
PR #224 introduced breaking changes in OG image paths. This PR fixes the meta tag according to the new format (I hope temporarily).

Created an issue in the `astro-og-canvas` repo - https://github.com/delucis/astro-og-canvas/issues/90