### PR TITLE
style(cookies): add style override for CookieYes tables

### DIFF
--- a/src/style/global.css
+++ b/src/style/global.css
@@ -282,3 +282,21 @@ starlight-tabs {
   background-color: var(--crowdin-gray-005) !important;
   box-shadow: inset 0 0 0 1px var(--crowdin-gray-01) !important;
 }
+
+/* CookieYes */
+
+[data-theme="dark"] .cky-cookie-audit-table th {
+  background-color: var(--color-gray-500) !important;
+  color: var(--sl-color-text) !important;
+  border-color: var(--color-gray-700) !important;
+}
+
+[data-theme="dark"] .cky-cookie-audit-table td {
+  background-color: var(--sl-color-bg) !important;
+  color: var(--sl-color-text) !important;
+  border-color: var(--color-gray-700) !important;
+}
+
+[data-theme="dark"] .cky-cookie-audit-table tr:nth-child(2n + 1) td {
+  background-color: var(--sl-color-bg-nav) !important;
+}


### PR DESCRIPTION
Added style override for CookieYes tables when dark theme is enabled.

Dark mode
<img width="1897" height="812" alt="image" src="https://github.com/user-attachments/assets/fc507508-5b08-4f74-9336-01e30ab5bed6" />

Auto mode (dark)
<img width="1898" height="816" alt="image" src="https://github.com/user-attachments/assets/56a5c5f4-71bb-4f35-921a-548a01697ffa" />

Light mode
<img width="1902" height="818" alt="image" src="https://github.com/user-attachments/assets/412ba8c9-58de-416a-918c-0cfad5c59f48" />

Auto mode (light)
<img width="1908" height="822" alt="image" src="https://github.com/user-attachments/assets/fa69b897-32ba-4849-b60f-ed536a70f1fa" />


Closes #170 