### PR TITLE
docs(roles): add the Permissions section with detailed action tables

### DIFF
--- a/src/content/docs/crowdin/team-management/roles.mdx
+++ b/src/content/docs/crowdin/team-management/roles.mdx
@@ -56,6 +56,101 @@ Blocked users cannot access the project and are restricted from performing any a
 
 **Use case:** Used when a user’s access to the project needs to be revoked.
 
+## Permissions
+
+The tables below summarize what each role can do, grouped by area of the product:
+
+- ✓ — the role can perform the action
+- ✗ — the role can't perform the action
+- A superscript number (for example, ✓¹) marks a conditional permission explained in the **Notes** under each table.
+
+### Project
+
+| Action                                                        | Owner | Manager | Developer | Language Coordinator | Proofreader | Translator |
+| ------------------------------------------------------------- | :---: | :-----: | :-------: | :------------------: | :---------: | :--------: |
+| View project dashboard and activity                           |   ✓   |    ✓    |     ✓     |          ✓           |      ✓      |     ✓      |
+| View project reports                                          |   ✓   |    ✓    |     ✗     |          ✓¹          |      ✗      |     ✗      |
+| View personal contributor reports                             |   ✓   |    ✓    |     ✓     |          ✓           |      ✓      |     ✓      |
+| Participate in discussions (view, create topics, reply)       |   ✓   |    ✓    |     ✓     |          ✓           |      ✓      |     ✓      |
+| Moderate discussions (edit / delete others' topics & replies) |   ✓   |    ✓    |     ✗     |          ✗           |      ✗      |     ✗      |
+| View tasks / open an assigned task                            |   ✓   |    ✓    |     ✓     |          ✓²          |     ✓²      |     ✓²     |
+| Manage tasks (create / edit / delete)                         |   ✓   |    ✓    |     ✗     |          ✓³          |      ✗      |     ✗      |
+| Close / change task status                                    |   ✓   |    ✓    |    ✓⁴     |          ✓⁴          |     ✓⁴      |     ✓⁴     |
+| Export / download a task                                      |   ✓   |    ✓    |     ✗     |          ✓⁵          |     ✓⁵      |     ✓⁵     |
+| Download a full project build (all target languages)          |   ✓   |    ✓    |     ✓     |          ✗           |      ✗      |     ✗      |
+| Download translations for a single target language            |   ✓   |    ✓    |     ✓     |          ✗           |     ✓⁵      |     ✓⁵     |
+
+**Notes**
+
+1. Language Coordinators can view project reports; the available report tier also depends on the account plan.
+2. Limited to tasks they're assigned to (Language Coordinators — tasks in their assigned languages).
+3. Only for their assigned languages.
+4. A user assigned to a task can advance its status but can't close it; Owners and Managers are unrestricted.
+5. Available only when **Allow offline translation** is enabled and the role has access to that language; with **task-based access** on, downloads happen through assigned tasks.
+
+### Project Settings
+
+| Action                                                                         | Owner | Manager | Developer | Language Coordinator | Proofreader | Translator |
+| ------------------------------------------------------------------------------ | :---: | :-----: | :-------: | :------------------: | :---------: | :--------: |
+| Edit project settings (name, languages, privacy, QA checks, branch protection) |   ✓   |    ✓    |     ✗     |          ✗           |      ✗      |     ✗      |
+| View members and their permissions                                             |   ✓   |    ✓    |     ✗     |          ✓           |      ✗      |     ✗      |
+| Invite members / assign roles                                                  |   ✓   |   ✓¹    |     ✗     |          ✓²          |      ✗      |     ✗      |
+| Manage members (remove / block / change status)                                |   ✓   |   ✓¹    |     ✗     |          ✗           |      ✗      |     ✗      |
+| Manage source files, branches, integrations, and webhooks                      |   ✓   |    ✓    |     ✓     |          ✗           |      ✗      |     ✗      |
+| Install and manage apps                                                        |  ✓³   |    ✗    |     ✗     |          ✗           |      ✗      |     ✗      |
+| Delete project / transfer ownership                                            |   ✓   |   ✓⁴    |     ✗     |          ✗           |      ✗      |     ✗      |
+
+**Notes**
+
+1. Managers can't edit the project Owner or themselves.
+2. Language Coordinators can invite members and assign roles, but only **Translator** or **Proofreader**, and only within their assigned languages; they can't grant Manager, Developer, or Language Coordinator roles, or manage invite links.
+3. Project owner only.
+4. Only a Manager granted project-deletion rights via **Allow this manager to create projects on behalf of your account** — a legacy option available only to accounts created before 14 February 2022 (or specifically allowlisted). A regular Manager can't.
+
+### Localization Resources
+
+Translation Memories, Machine Translation engines, and style guides are **account-level** resources managed by the project owner and any managers they assign as co-managers, regardless of project role. Anyone can create their own glossary; glossary deletion is limited to the glossary's owner. Working with glossary terms inside a project is governed by project membership and the project's **Glossary access** setting.
+
+| Action                                                          | Owner | Manager | Developer | Language Coordinator | Proofreader | Translator |
+| --------------------------------------------------------------- | :---: | :-----: | :-------: | :------------------: | :---------: | :--------: |
+| Create / edit / delete TM, MT engines, and style guides         |  ✓¹   |    ✗    |     ✗     |          ✗           |      ✗      |     ✗      |
+| Assign a TM, glossary, MT engine, or style guide to the project |   ✓   |   ✓²    |     ✗     |          ✗           |      ✗      |     ✗      |
+| Use MT suggestions in the Editor                                |   ✓   |    ✓    |     ✓     |          ✓³          |     ✓³      |     ✓³     |
+| Read glossary terms                                             |   ✓   |    ✓    |     ✓     |          ✓           |      ✓      |     ✓      |
+| Add / edit glossary terms                                       |   ✓   |    ✓    |    ✓⁴     |          ✓⁴          |     ✓⁴      |     ✓⁴     |
+
+**Notes**
+
+1. Available to the project owner and any resource co-managers, independent of project role.
+2. Only for the specific resources the Manager has been assigned to manage on the **Managers** page.
+3. Limited to the languages the role is assigned to.
+4. Depends on the project's **Glossary access** setting (Full / Drafts / Read-only); Owners and Managers always can.
+
+### Editor
+
+| Action                                         | Owner | Manager | Developer | Language Coordinator | Proofreader | Translator |
+| ---------------------------------------------- | :---: | :-----: | :-------: | :------------------: | :---------: | :--------: |
+| Add / save translation                         |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |     ✓¹     |
+| Approve / unapprove translation                |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |     ✗²     |
+| Vote on suggestions (+/−)                      |  ✗³   |   ✗³    |    ✗³     |          ✗³          |     ✗³      |    ✓¹ ³    |
+| Delete own translation                         |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |    ✓¹ ⁴    |
+| Delete others' translations                    |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |     ✗      |
+| Access hidden strings                          |   ✓   |    ✓    |     ✓     |          ✗           |     ✓⁵      |     ✗      |
+| Add comments & issues                          |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |     ✓¹     |
+| Resolve issues                                 |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |     ✓⁶     |
+| Edit source strings (context, key, max length) |   ✓   |    ✓    |     ✓     |          ✗           |      ✗      |     ✗      |
+| Add / edit glossary terms                      |  ✓⁷   |   ✓⁷    |    ✓⁷     |          ✓⁷          |     ✓⁷      |     ✓⁷     |
+
+**Notes**
+
+1. Limited to the language(s) the role is assigned to.
+2. Approving is reserved for Proofreaders and above; Translators can't approve.
+3. In the Editor, voting and approving are mutually exclusive — vote controls appear only for users who can't approve (Translators), and you can't vote on your own suggestion.
+4. Translators can delete only their own translations, and only when task-based access is off.
+5. Proofreaders can access hidden strings only when **Allow proofreaders to access hidden strings** is enabled; Owners, Managers, and Developers always can.
+6. Translators can resolve only issues they opened.
+7. Depends on the project's **Glossary access** setting (Full / Drafts / Read-only); Owners and Managers always can.
+
 ## See Also
 
 <LinkCard

--- a/src/content/docs/crowdin/team-management/roles.mdx
+++ b/src/content/docs/crowdin/team-management/roles.mdx
@@ -75,7 +75,7 @@ The tables below summarize what each role can do, grouped by area of the product
 | Moderate discussions (edit / delete others' topics & replies) |   ✓   |    ✓    |     ✗     |          ✗           |      ✗      |     ✗      |
 | View tasks / open an assigned task                            |   ✓   |    ✓    |     ✓     |          ✓²          |     ✓²      |     ✓²     |
 | Manage tasks (create / edit / delete)                         |   ✓   |    ✓    |     ✗     |          ✓³          |      ✗      |     ✗      |
-| Close / change task status                                    |   ✓   |    ✓    |    ✓⁴     |          ✓⁴          |     ✓⁴      |     ✓⁴     |
+| Change task status                                            |   ✓   |    ✓    |    ✓⁴     |          ✓⁴          |     ✓⁴      |     ✓⁴     |
 | Export / download a task                                      |   ✓   |    ✓    |     ✗     |          ✓⁵          |     ✓⁵      |     ✓⁵     |
 | Download a full project build (all target languages)          |   ✓   |    ✓    |     ✓     |          ✗           |      ✗      |     ✗      |
 | Download translations for a single target language            |   ✓   |    ✓    |     ✓     |          ✗           |     ✓⁵      |     ✓⁵     |
@@ -109,7 +109,7 @@ The tables below summarize what each role can do, grouped by area of the product
 
 ### Localization Resources
 
-Translation Memories, Machine Translation engines, and style guides are **account-level** resources managed by the project owner and any managers they assign as co-managers, regardless of project role. Anyone can create their own glossary; glossary deletion is limited to the glossary's owner. Working with glossary terms inside a project is governed by project membership and the project's **Glossary access** setting.
+Translation Memories, Machine Translation engines, and style guides are **account-level** resources managed by the project owner and any resource co-managers (configured on the **Managers** page), regardless of project role. Anyone can create their own glossary; glossary deletion is limited to the glossary's owner. Working with glossary terms inside a project is governed by project membership and the project's **Glossary access** setting.
 
 | Action                                                          | Owner | Manager | Developer | Language Coordinator | Proofreader | Translator |
 | --------------------------------------------------------------- | :---: | :-----: | :-------: | :------------------: | :---------: | :--------: |
@@ -132,8 +132,8 @@ Translation Memories, Machine Translation engines, and style guides are **accoun
 | ---------------------------------------------- | :---: | :-----: | :-------: | :------------------: | :---------: | :--------: |
 | Add / save translation                         |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |     ✓¹     |
 | Approve / unapprove translation                |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |     ✗²     |
-| Vote on suggestions (+/−)                      |  ✗³   |   ✗³    |    ✗³     |          ✗³          |     ✗³      |    ✓¹ ³    |
-| Delete own translation                         |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |    ✓¹ ⁴    |
+| Vote on suggestions (+/−)                      |  ✗³   |   ✗³    |    ✗³     |          ✗³          |     ✗³      |     ✓³     |
+| Delete own translation                         |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |     ✓⁴     |
 | Delete others' translations                    |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |     ✗      |
 | Access hidden strings                          |   ✓   |    ✓    |     ✓     |          ✗           |     ✓⁵      |     ✗      |
 | Add comments & issues                          |   ✓   |    ✓    |     ✓     |          ✓¹          |     ✓¹      |     ✓¹     |
@@ -145,8 +145,8 @@ Translation Memories, Machine Translation engines, and style guides are **accoun
 
 1. Limited to the language(s) the role is assigned to.
 2. Approving is reserved for Proofreaders and above; Translators can't approve.
-3. In the Editor, voting and approving are mutually exclusive — vote controls appear only for users who can't approve (Translators), and you can't vote on your own suggestion.
-4. Translators can delete only their own translations, and only when task-based access is off.
+3. In the Editor, voting and approving are mutually exclusive — vote controls appear only for Translators, who can vote only within their assigned languages and can't vote on their own suggestion.
+4. Translators can delete only their own translations, within their assigned languages, and only when task-based access is off.
 5. Proofreaders can access hidden strings only when **Allow proofreaders to access hidden strings** is enabled; Owners, Managers, and Developers always can.
 6. Translators can resolve only issues they opened.
 7. Depends on the project's **Glossary access** setting (Full / Drafts / Read-only); Owners and Managers always can.


### PR DESCRIPTION
Add a Permissions section to the Roles article (Crowdin) with per-role permission tables grouped by area (Project, Project Settings, Localization Resources, Editor), using ✓/✗ marks and footnotes for conditional access.