### PR TITLE
docs(tasks): document task scope, column display, and refresh filters

### DIFF
--- a/src/content/docs/crowdin/tasks/tasks.mdx
+++ b/src/content/docs/crowdin/tasks/tasks.mdx
@@ -222,7 +222,9 @@ Use the **Search tasks** field to search for tasks by name or [filter tasks](#fi
 
 The **All Tasks** section provides a list view of all project tasks. It is particularly useful for efficiently managing large volumes of tasks. From this view, you can select multiple tasks to perform bulk actions, such as changing assignees, updating statuses, or deleting tasks.
 
-Similar to the **Board** section, the **All Tasks** view also allows you to use the **Search tasks** field and [filter](#filtering-tasks). Additionally, you can sort the task list in ascending or descending order using the available sort options (ID, Created at, Resolved at, Due Date).
+Similar to the **Board** section, the **All Tasks** view also allows you to use the **Search tasks** field and [filter](#filtering-tasks). Additionally, you can sort the task list in ascending or descending order using the available sort options (ID, Created at, Started at, Resolved at, Due Date).
+
+You can also choose which columns are displayed. Click <Icon name="mdi:view-column" class="inline-icon" /> **Columns** to show or hide optional columns &ndash; **Created at**, **Started at**, and **Resolved at** are hidden by default. The **Type**, **ID**, and **Title** columns are always visible and can't be hidden.
 
 #### Generating Reports for Multiple Tasks
 
@@ -259,6 +261,15 @@ To change the task details, follow these steps:
   If the source file is restored to the revision containing the removed strings, they will reappear in the task.
 </QuestionAnswer>
 
+### Task Scope
+
+When you open a task, its details display the word scope:
+
+* **Original scope** &ndash; the number of words included in the task when it was created.
+* **Current scope** &ndash; the number of words currently included in the task.
+
+After a task is created, its scope may change if the source strings included in the task are edited or removed in the project. When the current scope differs from the original one, a <Icon name="mdi:help-circle-outline" class="inline-icon" /> icon appears next to the **Current scope** value. Hover over it to see how much the scope has changed (e.g., *Scope reduced by 30 words*).
+
 ### Viewing Tasks Created Together
 
 When you create tasks for multiple languages at once, they are generated as a single batch. To easily find and navigate between all tasks from the same batch, you can use the **Tasks Created Together** option.
@@ -277,14 +288,18 @@ You will be redirected to the **All Tasks** section with a `batchId` filter (e.g
 
 By default, all project tasks are displayed in the **Tasks** tab either in the **Board** or **All Tasks** sections. If necessary, you can filter tasks using the available filter options:
 
+* Type: All types, Translate by own translators, Proofread by own proofreaders, Translate by vendor, Proofread by vendor.
 * Assignee: All users or particular user.
 * Created by: All users or particular user.
 * Language: All languages or particular language.
 * File: All files or particular file or folder.
 * Due date: All, Overdue now, Custom Range.
 * Created at: All, Today, Yesterday, Last 7 days, Last 30 days, This month, Last month, Custom Range.
-* Type: All types, Translate by own translators, Proofread by own proofreaders, Translate by vendor, Proofread by vendor.
-* Status: All statuses, To Do, In Progress, Done, Closed.
+* Started at: same date options as Created at.
+* Resolved at: same date options as Created at.
+* Status: All statuses, To Do, In Progress, Done, Closed, Pending.
+
+The **Started at**, **Resolved at**, and **Status** filters are available only in the **All Tasks** view.
 
 <Image src={filter} alt="Filtering Tasks" />
 

--- a/src/content/docs/crowdin/tasks/user-tasks.mdx
+++ b/src/content/docs/crowdin/tasks/user-tasks.mdx
@@ -107,6 +107,8 @@ In addition to the details available when [viewing all of your assigned tasks](#
 * Modified &ndash; when the task was last modified.
 * Started &ndash; when work on the task began.
 * Resolved &ndash; when the task was completed.
+* Original scope &ndash; the number of words included in the task when it was created.
+* Current scope &ndash; the number of words currently included in the task. If it differs from the original scope, hover over the <Icon name="mdi:help-circle-outline" class="inline-icon" /> icon to see how much it has changed.
 * Strings modified &ndash; the modification period for strings included in the task.
 * Members &ndash; a list of assignees with the time spent, words assigned, and words left for each member.
 * Files &ndash; files associated with the task.

--- a/src/content/docs/enterprise/tasks/tasks.mdx
+++ b/src/content/docs/enterprise/tasks/tasks.mdx
@@ -208,7 +208,7 @@ In the **Tasks** section, you can view all the project tasks in the following tw
 
 ### Board
 
-In the **Board** section, tasks are organized into three columns: To Do, In Progress, and Done. This layout provides a clear view and visualization of the current status of all tasks. Within each column, tasks are further grouped by target languages. Each target language group can be collapsed to hide task cards or expanded to display them. This feature is particularly useful for decluttering the view and focusing on specific languages.
+In the **Board** section, tasks are organized into three columns: To Do, In Progress, and Done. This layout provides a clear view and visualization of the current status of all tasks. To group tasks by target language within each column, select the **Group by language** checkbox. Each target language group can then be collapsed to hide task cards or expanded to display them. This is particularly useful for decluttering the view and focusing on specific languages.
 
 Use the **Search** field to search for tasks by name or [filter tasks](#filtering-tasks) using various filter options. To view the task details, open it by clicking on the task name.
 
@@ -218,7 +218,9 @@ Use the **Search** field to search for tasks by name or [filter tasks](#filterin
 
 The **All Tasks** section provides a list view of all project tasks. It is particularly useful for efficiently managing large volumes of tasks. From this view, you can select multiple tasks to perform bulk actions, such as changing assignees, updating statuses, or deleting tasks.
 
-Similar to the **Board** section, the **All Tasks** view also allows you to use the **Search** field and [filter](#filtering-tasks). Additionally, you can sort the task list in ascending or descending order using the available sort options (ID, Created at, Resolved at, Due Date).
+Similar to the **Board** section, the **All Tasks** view also allows you to use the **Search** field and [filter](#filtering-tasks). Additionally, you can sort the task list in ascending or descending order using the available sort options (ID, Created, Start date, Resolved date, Due date).
+
+You can also choose which columns are displayed. Click <Icon name="material-symbols:table-chart" class="inline-icon" /> **Select columns** to show or hide optional columns &ndash; **Workflow step**, **Created**, **Start date**, and **Resolved date** are hidden by default. The **ID**, **Type**, and **Title** columns are always visible and can't be hidden.
 
 #### Generating Reports for Multiple Tasks
 
@@ -254,6 +256,15 @@ To change the task details, follow these steps:
   If the source file is restored to the revision containing the removed strings, they will reappear in the task.
 </QuestionAnswer>
 
+### Task Scope
+
+When you open a task, its details display the word scope:
+
+* **Original scope** &ndash; the number of words included in the task when it was created.
+* **Current scope** &ndash; the number of words currently included in the task.
+
+After a task is created, its scope may change if the source strings included in the task are edited or removed in the project. When the current scope differs from the original one, a <Icon name="mdi:help-circle-outline" class="inline-icon" /> icon appears next to the **Current scope** value. Hover over it to see how much the scope has changed (e.g., *Scope reduced by 30 words*).
+
 ### Viewing Tasks Created Together
 
 When you create tasks for multiple languages at once, they are generated as a single batch. To easily find and navigate between all tasks from the same batch, you can use the **Tasks Created Together** option.
@@ -272,15 +283,19 @@ You will be redirected to the **All Tasks** section with a `batchId` filter (e.g
 
 By default, all project tasks are displayed in the **Tasks** section either in the **Board** or **All Tasks** sections. If necessary, you can filter tasks using the available filter options:
 
+* Type: All types, Translate by own translators, Proofread by own proofreaders, Translate by vendor, Proofread by vendor.
 * Target language: All languages or particular language.
 * Assignee: All users or particular user.
 * Created by: All users or particular user.
 * Due date: All, Overdue now, Custom range.
-* Created: All, Custom range.
-* Type: All types, Translate by own translators, Proofread by own proofreaders, Translate by vendor, Proofread by vendor.
+* Created: All, Today, Yesterday, Last 7 days, Last 30 days, Last month, Custom range.
+* Start date: same date options as Created.
+* Resolved date: same date options as Created.
 * Workflow step: All, No workflow step, or particular workflow step.
 * File: All files or particular file or folder.
-* Status: All statuses, To Do, In Progress, Done, Closed.
+* Status: All statuses, To Do, In Progress, Done, Closed, Pending, For Approval.
+
+The **Start date**, **Resolved date**, and **Status** filters are available only in the **All Tasks** view. On the **Board**, you can additionally filter by any [task fields](/enterprise/fields/) configured for your organization.
 
 <Image src={filter} alt="Filtering Tasks" />
 

--- a/src/content/docs/enterprise/tasks/user-tasks.mdx
+++ b/src/content/docs/enterprise/tasks/user-tasks.mdx
@@ -110,6 +110,8 @@ The task opens directly within the project it's associated with. Alternatively, 
 In addition to the details available when [viewing all of your assigned tasks](#searching-filtering-and-sorting-assigned-tasks), you will also see these details:
 
 * Created by &ndash; the user who created the task.
+* Original scope &ndash; the number of words included in the task when it was created.
+* Current scope &ndash; the number of words currently included in the task. If it differs from the original scope, hover over the <Icon name="mdi:help-circle-outline" class="inline-icon" /> icon to see how much it has changed.
 * Created &ndash; when the task was created.
 * Started date &ndash; when the task moved to **In Progress**, **Done**, or **Closed**.
 * Resolved date &ndash; when the task moved to **Done** or **Closed**.


### PR DESCRIPTION
- Add Task Scope (Original vs Current scope) to Project Tasks and User Tasks
- Document All Tasks column visibility control
- Clarify Board "Group by language" toggle (Enterprise)
- Refresh filter and sort lists; note Board vs All Tasks filter differences