### PR TITLE
feat: add click-to-zoom for article screenshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "astro-og-canvas": "^0.10.1",
     "canvaskit-wasm": "^0.40.0",
     "github-slugger": "^2.0.0",
+    "medium-zoom": "^1.1.0",
     "redoc": "2.5.2",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-external-links": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      medium-zoom:
+        specifier: ^1.1.0
+        version: 1.1.0
       redoc:
         specifier: 2.5.2
         version: 2.5.2(core-js@3.49.0)(mobx@6.16.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -2386,6 +2389,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  medium-zoom@1.1.0:
+    resolution: {integrity: sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -6176,6 +6182,8 @@ snapshots:
   mdn-data@2.0.30: {}
 
   mdn-data@2.27.1: {}
+
+  medium-zoom@1.1.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import Default from '@astrojs/starlight/components/Footer.astro';
 import Feedback from '~/components/Feedback.astro';
+import ImageZoom from '~/components/ImageZoom.astro';
 import { getRelativeLocaleUrl } from 'astro:i18n';
 import { isStarlightHomepage } from '~/utils/starlightRoute';
 
@@ -49,3 +50,5 @@ const showFeedback = !isHomepage &&
         </div>
     </div>
 )}
+
+{showFeedback && <ImageZoom />}

--- a/src/components/ImageZoom.astro
+++ b/src/components/ImageZoom.astro
@@ -1,0 +1,49 @@
+---
+// Click-to-zoom for UI screenshots inside article content.
+// Attaches medium-zoom to images in `.sl-markdown-content`, skipping images
+// that are wrapped in a link (those stay clickable).
+---
+
+<script>
+    import mediumZoom from 'medium-zoom';
+
+    let zoom: ReturnType<typeof mediumZoom> | undefined;
+
+    function setupImageZoom() {
+        const images = [...document.querySelectorAll<HTMLImageElement>('.sl-markdown-content img')]
+            .filter((img) => !img.closest('a'));
+
+        if (!images.length) return;
+
+        if (!zoom) {
+            zoom = mediumZoom(images, {
+                margin: 24,
+                background: 'rgba(0, 0, 0, 0.8)',
+            });
+        } else {
+            zoom.detach();
+            zoom.attach(images);
+        }
+    }
+
+    // Module scripts are deferred, so the content is already in the DOM.
+    setupImageZoom();
+
+    // Re-attach after client-side navigation (if View Transitions get enabled).
+    document.addEventListener('astro:page-load', setupImageZoom);
+</script>
+
+<style is:global>
+    .sl-markdown-content .medium-zoom-image {
+        cursor: zoom-in;
+    }
+
+    .medium-zoom-overlay,
+    .medium-zoom-image--opened {
+        z-index: 1000;
+    }
+
+    .medium-zoom-image--opened {
+        cursor: zoom-out;
+    }
+</style>


### PR DESCRIPTION
Attach medium-zoom to images in .sl-markdown-content so UI screenshots open in an enlarged overlay on click (Esc/click/scroll to close). Skips images wrapped in links; scoped to article pages via Footer.