### PR TITLE
docs(qa-checks): document spell checker capabilities

### DIFF
--- a/src/content/docs/crowdin/project-management/project-settings/qa-checks.mdx
+++ b/src/content/docs/crowdin/project-management/project-settings/qa-checks.mdx
@@ -113,7 +113,17 @@ Once revalidation starts, the button is disabled and a **Cancel** button appears
 
 **Outdated translation** &ndash; flags translations that may need to be revised after their corresponding source strings have been modified.
 
-## Spell Checker Ignore List
+## Spell Checker
+
+The spell checker powers the **Spelling mistakes** QA check for supported languages, and you can manage the words it ignores per project.
+
+### How the Spell Checker Works
+
+The spell checker does more than catch misspelled words. For supported languages, it can also flag grammar, punctuation, and capitalization issues, though coverage depends on the language.
+
+Spellcheck explanations are shown in the target language you’re translating into, not in your interface language, so they read naturally for that language’s linguists.
+
+### Spell Checker Ignore List
 
 If your project contains some uncommon words that are not recognized by the Spell checker, you can add them to the Ignore list to exclude them from being checked.
 

--- a/src/content/docs/enterprise/project-management/project-settings/qa-checks.mdx
+++ b/src/content/docs/enterprise/project-management/project-settings/qa-checks.mdx
@@ -148,7 +148,19 @@ Once revalidation starts, the button is disabled and a **Cancel** button appears
 
 **Outdated translation** &ndash; flags translations that may need to be revised after their corresponding source strings have been modified.
 
-## Spell Checker Ignore List
+## Spell Checker
+
+The spell checker powers the **Spelling mistakes** QA check for supported languages, and you can manage the words it ignores per project.
+
+### How the Spell Checker Works
+
+The spell checker does more than catch misspelled words. For supported languages, it can also flag grammar, punctuation, and capitalization issues, though coverage depends on the language.
+
+Spellcheck explanations are shown in the target language you’re translating into, not in your interface language, so they read naturally for that language’s linguists.
+
+If a [custom spellchecker](/enterprise/organization-settings/#spellcheckers) is installed for a language, it handles the check for that language instead.
+
+### Spell Checker Ignore List
 
 If your project contains some uncommon words that are not recognized by the Spell checker, you can add them to the Ignore list to exclude them from being checked.
 


### PR DESCRIPTION
- Add "Spell Checker" section (Crowdin + Enterprise) grouping a new "How the Spell Checker Works" subsection with the existing Ignore List
- Clarify that supported languages get grammar/punctuation/capitalization checks (not just spelling) and explanations show in the target language
- Enterprise: note an installed custom spellchecker handles its language
- Follows the repo's "## Feature > ### How X Works" pattern (cf. AI QA Check)
- Keep the Ignore List heading text so its anchor stays stable