### PR TITLE
docs(developer): document serverless apps and API requests

### DIFF
--- a/src/content/docs/developer/crowdin-apps/about-crowdin-apps.mdx
+++ b/src/content/docs/developer/crowdin-apps/about-crowdin-apps.mdx
@@ -39,13 +39,48 @@ import integratingCrowdinApps from '~/assets/images/integrating-crowdin-apps.svg
 
 By creating Crowdin apps, developers can integrate existing services with Crowdin, add new features, upload and manage content.
 
-Crowdin apps are web applications that function remotely via HTTP. To an end user, an app appears as a fully integrated part of Crowdin. Once your app is installed, its features are delivered straight to the Crowdin UI.
+To an end user, an app appears as a fully integrated part of Crowdin. Once your app is installed, its features are delivered straight to the Crowdin UI.
 
-You can develop a Crowdin app using any of the preferred programming languages and web frameworks, and deploy it in many different ways. From massive SaaS services to static apps served right from a code repo, Crowdin apps are designed to let you connect anything to Crowdin.
+## Choose How to Build
 
-<Image src={integratingCrowdinApps} alt="Integrating with Crowdin Diagram" class="no-shadow" />
+There are two ways to build a Crowdin app. Serverless apps run on Crowdin infrastructure: you write the UI, and Crowdin hosts and runs the app. Self-hosted apps run on a server you operate, which lets them use every module type, including those with server-side logic. Neither approach replaces the other. Pick the one that matches what your app does.
+
+<CardGrid>
+  <Card title="Serverless Apps" icon="rocket">
+    Build dashboards, panels, and other UI modules that run on Crowdin infrastructure. You scaffold, preview, and publish the app from the CLI, with no server to deploy or maintain.
+
+    Choose this path when your app is all interface: it displays data, extends the Crowdin UI, and calls the Crowdin API on behalf of the person using it.
+
+    [Get started with Serverless Apps](/developer/crowdin-apps-serverless/)
+  </Card>
+  <Card title="Self-Hosted Apps" icon="setting">
+    Build an app backed by your own server, using any language and framework. This path supports every module type, including file processing, AI providers, and custom MT engines.
+
+    Choose this path when your app needs server-side logic: it processes files, reacts to webhooks, connects external services, or acts with the permissions of the account that installed it. Also choose it if you plan to publish the app on the [Crowdin Store](https://store.crowdin.com).
+
+    [Follow the Quick Start](/developer/crowdin-apps-quick-start/)
+  </Card>
+</CardGrid>
+
+|              | Serverless Apps                                | Self-Hosted Apps                                  |
+|--------------|------------------------------------------------|---------------------------------------------------|
+| Hosting      | Crowdin runs your app                          | You deploy and run your app                        |
+| Modules      | UI modules                                     | All module types                                   |
+| API calls    | Made as the user working in the app            | Made as the account that installed the app         |
+| Stack        | TypeScript, with React and the Crowdin UI Kit preconfigured | Any language and framework           |
+| Distribution | Published from the CLI, available in your account | Available in your account; can also be published on the Crowdin Store |
+
+If your app combines an interface with server-side logic, build it as a self-hosted app. Self-hosted apps can include UI modules as well.
 
 ## Creating Crowdin Apps
+
+<Aside>
+  The sections below describe how self-hosted apps work.
+</Aside>
+
+Self-hosted apps are web applications that function remotely via HTTP. You can develop them using any of the preferred programming languages and web frameworks, and deploy them in many different ways. From massive SaaS services to static apps served right from a code repo, self-hosted apps are designed to let you connect anything to Crowdin.
+
+<Image src={integratingCrowdinApps} alt="Integrating with Crowdin Diagram" class="no-shadow" />
 
 The development of Crowdin App starts with creating an app descriptor. The app descriptor is a JSON file that describes the interaction of the app with Crowdin. The descriptor includes general information for the app, as well as the modules that the app will be using or extending. Basically, the descriptor is a middle ground between the remote app and Crowdin. When a Crowdin account owner installs an app, what they are really doing is installing this descriptor file, which contains pointers to your app.
 
@@ -68,8 +103,8 @@ The next step would be to implement the app functionality according to the app d
   Read more about [UI Modules](/developer/crowdin-apps-modules-ui/) and [File Processing Modules](/developer/crowdin-apps-modules-file-processing/).
 </ReadMore>
 
-<Aside type="tip" title="Interested in developing Crowdin Apps?">
-  Check out our [Crowdin Apps SDK](https://crowdin.github.io/app-project-module/) to create apps in just a few lines of code.
+<Aside type="tip" title="Interested in developing self-hosted apps?">
+  Check out the [Crowdin Apps SDK](https://crowdin.github.io/app-project-module/) to build a self-hosted app in just a few lines of code.
 </Aside>
 
 ## Using Crowdin APIs in Crowdin Apps

--- a/src/content/docs/developer/crowdin-apps/about-crowdin-apps.mdx
+++ b/src/content/docs/developer/crowdin-apps/about-crowdin-apps.mdx
@@ -56,7 +56,7 @@ There are two ways to build a Crowdin app. Serverless apps run on Crowdin infras
   <Card title="Self-Hosted Apps" icon="setting">
     Build an app backed by your own server, using any language and framework. This path supports every module type, including file processing, AI providers, and custom MT engines.
 
-    Choose this path when your app needs server-side logic: it processes files, reacts to webhooks, connects external services, or acts with the permissions of the account that installed it. Also choose it if you plan to publish the app on the [Crowdin Store](https://store.crowdin.com).
+    Choose this path when your app needs server-side logic: it processes files, reacts to webhooks, connects external services, or acts with the permissions of the account that installed it.
 
     [Follow the Quick Start](/developer/crowdin-apps-quick-start/)
   </Card>
@@ -68,7 +68,6 @@ There are two ways to build a Crowdin app. Serverless apps run on Crowdin infras
 | Modules      | UI modules                                     | All module types                                   |
 | API calls    | Made as the user working in the app            | Made as the account that installed the app         |
 | Stack        | TypeScript, with React and the Crowdin UI Kit preconfigured | Any language and framework           |
-| Distribution | Published from the CLI, available in your account | Available in your account; can also be published on the Crowdin Store |
 
 If your app combines an interface with server-side logic, build it as a self-hosted app. Self-hosted apps can include UI modules as well.
 

--- a/src/content/docs/developer/crowdin-apps/apps-js.mdx
+++ b/src/content/docs/developer/crowdin-apps/apps-js.mdx
@@ -443,6 +443,142 @@ This method returns a plain **`string`** which is the JWT token, or **`null`**.
 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkw...SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 ```
 
+### Making API Requests
+
+You can call the Crowdin REST API from your app on behalf of the current user, either directly or through the official API client.
+
+#### AP.apiRequest(payload, callback) {#api-request}
+
+Your app can call the Crowdin REST API directly from the iframe. Crowdin executes each request on behalf of the current user and limits it to the scopes declared in the app manifest, so no tokens are needed in your code.
+
+**Example:**
+
+```js
+AP.apiRequest(
+  { method: "get", path: "projects?limit=25", headers: {} },
+  (res) => {
+    if (res.status >= 200 && res.status < 300) {
+      console.log(res.body.data);
+    }
+  },
+);
+```
+
+##### Parameters
+
+<table>
+  <tbody>
+  <tr>
+    <td><code class="whitespace-nowrap">payload</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>object</code></p>
+      <p><strong>Required:</strong> yes</p>
+      <p><strong>Description:</strong> The request definition. See the payload fields below.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code class="whitespace-nowrap">callback</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>function</code></p>
+      <p><strong>Required:</strong> yes</p>
+      <p><strong>Description:</strong> A function that receives the response envelope with the status, statusText, and body properties.</p>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+##### Payload Fields
+
+<table>
+  <tbody>
+  <tr>
+    <td><code class="whitespace-nowrap">method</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code></p>
+      <p><strong>Required:</strong> yes</p>
+      <p><strong>Description:</strong> HTTP method: <code>get</code>, <code>post</code>, <code>put</code>, <code>patch</code>, <code>delete</code>, or <code>head</code>.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code class="whitespace-nowrap">path</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code></p>
+      <p><strong>Required:</strong> yes</p>
+      <p><strong>Description:</strong> Path relative to <code>/api/v2</code>, including the query string. For example, <code>projects?limit=25</code>.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code class="whitespace-nowrap">headers</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>object</code></p>
+      <p><strong>Required:</strong> yes</p>
+      <p><strong>Description:</strong> Additional request headers. Pass an empty object when none are needed.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code class="whitespace-nowrap">body</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>object | string | ArrayBuffer</code></p>
+      <p><strong>Required:</strong> no</p>
+      <p><strong>Description:</strong> Request body: a JSON-serializable value, a string, or an <code>ArrayBuffer</code> for binary data. <code>FormData</code> is not supported (no API v2 endpoint requires multipart). To upload a file, read it into an <code>ArrayBuffer</code> first.</p>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+##### Response
+
+The callback receives a response envelope with three properties: `status`, `statusText`, and `body`. Crowdin returns this envelope for every completed request, whether it succeeded or not, so a non-2xx response does not throw. A `status` of `0` indicates a network failure.
+
+The `body` is a parsed JSON value for JSON responses, a string for text responses, and an `ArrayBuffer` for binary ones. It is absent when the response has no body.
+
+##### Uploading a File
+
+```js
+const buffer = await file.arrayBuffer();
+
+AP.apiRequest(
+  {
+    method: "post",
+    path: "storages",
+    headers: { "Crowdin-API-FileName": file.name },
+    body: buffer,
+  },
+  (res) => console.log(res.body.data),
+);
+```
+
+#### Using the Official API Client {#api-client}
+
+Instead of calling `AP.apiRequest` directly, you can use the official [`@crowdin/crowdin-api-client`](https://www.npmjs.com/package/@crowdin/crowdin-api-client) with the `@crowdin/apps-api-adapter` package. The adapter implements the client's HTTP layer on top of `AP.apiRequest`, so you get the full typed API surface while every request still runs under the current user's session and manifest scopes.
+
+```bash
+npm install @crowdin/apps-api-adapter @crowdin/crowdin-api-client
+```
+
+```js
+import { AppsApiAdapter } from "@crowdin/apps-api-adapter";
+import { Client } from "@crowdin/crowdin-api-client";
+
+const crowdin = new Client(
+  { token: "unused" },
+  { httpClient: new AppsApiAdapter() },
+);
+
+const { data: projects } = await crowdin.projectsGroupsApi.listProjects();
+
+const file = document.querySelector("#file").files[0];
+await crowdin.uploadStorageApi.addStorage(file.name, file);
+```
+
+<Aside type="note">
+  The `token` is required by the client constructor but never used. The host authenticates every request with the current user's session.
+</Aside>
+
+* Binary uploads accept a `Blob`, `File`, `ArrayBuffer`, or typed array; the adapter converts them automatically.
+* Failed requests reject with the client's usual `CrowdinError` / `CrowdinValidationError`.
+* GraphQL is not available through the bridge; only the REST API (`/api/v2`) is.
+
 ### Viewport and Sizing
 
 This group of methods allows your app to get information about the size and position of its `iframe` and to request size changes.

--- a/src/content/docs/developer/crowdin-apps/apps-js.mdx
+++ b/src/content/docs/developer/crowdin-apps/apps-js.mdx
@@ -550,7 +550,7 @@ AP.apiRequest(
 
 #### Using the Official API Client {#api-client}
 
-Instead of calling `AP.apiRequest` directly, you can use the official [`@crowdin/crowdin-api-client`](https://www.npmjs.com/package/@crowdin/crowdin-api-client) with the `@crowdin/apps-api-adapter` package. The adapter implements the client's HTTP layer on top of `AP.apiRequest`, so you get the full typed API surface while every request still runs under the current user's session and manifest scopes.
+Instead of calling `AP.apiRequest` directly, you can use the official [`@crowdin/crowdin-api-client`](https://npmx.dev/package/@crowdin/crowdin-api-client) with the [`@crowdin/apps-api-adapter`](https://npmx.dev/package/@crowdin/apps-api-adapter) package. The adapter implements the client's HTTP layer on top of `AP.apiRequest`, so you get the full typed API surface while every request still runs under the current user's session and manifest scopes.
 
 ```bash
 npm install @crowdin/apps-api-adapter @crowdin/crowdin-api-client

--- a/src/content/docs/developer/crowdin-apps/quick-start.mdx
+++ b/src/content/docs/developer/crowdin-apps/quick-start.mdx
@@ -1,12 +1,16 @@
 ---
 title: Quick Start
-description: Learn how to build a Crowdin Application using Node.js
+description: Learn how to build a self-hosted Crowdin app using Node.js
 slug: developer/crowdin-apps-quick-start
 ---
 
 import { Steps, Aside, CardGrid, LinkCard, Tabs, TabItem } from '@astrojs/starlight/components';
 
-In this article, you'll learn the basic principles of building a Crowdin Application using Node.js and the Vercel platform. You'll build and deploy a sample app using Next.js along the way.
+In this article, you'll learn the basic principles of building a self-hosted Crowdin app using Node.js and the Vercel platform. You'll build and deploy a sample app using Next.js along the way.
+
+<Aside type="tip" title="Building a UI-only app?">
+  This tutorial covers the self-hosted path. If your app only needs UI modules, you can build it as a [Serverless App](/developer/crowdin-apps-serverless/) instead, with no backend to host.
+</Aside>
 
 **Prerequisites**:
 
@@ -97,8 +101,8 @@ At this point, you have a working app with the following structure:
 
 In the current state, the app includes only the **Project Menu** module and does not yet require authentication. You’ll add OAuth and custom file format support in the next steps.
 
-<Aside type="tip" title="Interested in developing Crowdin Apps?">
-  Check out our [Crowdin Apps SDK](https://crowdin.github.io/app-project-module/) to create apps in just a few lines of code.
+<Aside type="tip" title="Interested in developing self-hosted apps?">
+  Check out the [Crowdin Apps SDK](https://crowdin.github.io/app-project-module/) to build a self-hosted app in just a few lines of code.
 </Aside>
 
 ## App Manifest

--- a/src/content/docs/developer/crowdin-apps/serverless-apps.mdx
+++ b/src/content/docs/developer/crowdin-apps/serverless-apps.mdx
@@ -1,0 +1,49 @@
+---
+title: Serverless Apps
+description: Build UI apps that run on Crowdin infrastructure, with no backend to host.
+slug: developer/crowdin-apps-serverless
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+import ReadMore from '~/components/ReadMore.astro';
+
+Serverless apps run entirely on Crowdin infrastructure. You write the UI, and Crowdin hosts and runs the app, so there is no backend to deploy or maintain. Serverless apps support UI modules such as project dashboards, editor panels, and menu extensions, and call the Crowdin API on behalf of the person using the app.
+
+You build a serverless app with the Crowdin Serverless Apps SDK and its CLI. The starter templates come with TypeScript, React, a UI kit styled to match Crowdin, and an i18n runtime.
+
+The Serverless Apps SDK has its own documentation with templates, guides, and an API reference:
+
+<LinkCard
+  title="Serverless Apps SDK"
+  description="Templates, SDK guides, CLI commands, and API reference."
+  href="https://crowdin.github.io/serverless-apps/"
+/>
+
+## Building a Serverless App
+
+Everything happens in the terminal: scaffold an app from a template, run it live inside Crowdin, and publish it.
+
+```bash
+npm install --global @crowdin/serverless-apps-cli
+crowdin-serverless-apps login
+crowdin-serverless-apps create my-app
+crowdin-serverless-apps dev
+crowdin-serverless-apps preview
+crowdin-serverless-apps publish
+```
+
+The published app is installed in your account, and the manifest controls who can use it.
+
+<ReadMore>
+  Read more about each step in the [Quick Start](https://crowdin.github.io/serverless-apps/getting-started/quick-start/).
+</ReadMore>
+
+## When to Build a Self-Hosted App Instead
+
+Serverless apps cover the UI side of Crowdin. When your app needs server-side logic (for example, file processing, AI providers, custom MT engines, or webhook handling), build it as a self-hosted app. The same applies when your app combines an interface with server-side logic: self-hosted apps can include UI modules as well.
+
+A self-hosted app also works with the Crowdin API differently: it makes calls as the account that installed it, not as the person using it. Choose this path as well if you plan to publish the app on the [Crowdin Store](https://store.crowdin.com).
+
+<ReadMore>
+  Read more about building a self-hosted app in the [Quick Start](/developer/crowdin-apps-quick-start/).
+</ReadMore>

--- a/src/content/docs/developer/crowdin-apps/serverless-apps.mdx
+++ b/src/content/docs/developer/crowdin-apps/serverless-apps.mdx
@@ -42,7 +42,7 @@ The published app is installed in your account, and the manifest controls who ca
 
 Serverless apps cover the UI side of Crowdin. When your app needs server-side logic (for example, file processing, AI providers, custom MT engines, or webhook handling), build it as a self-hosted app. The same applies when your app combines an interface with server-side logic: self-hosted apps can include UI modules as well.
 
-A self-hosted app also works with the Crowdin API differently: it makes calls as the account that installed it, not as the person using it. Choose this path as well if you plan to publish the app on the [Crowdin Store](https://store.crowdin.com).
+A self-hosted app also works with the Crowdin API differently: it makes calls as the account that installed it, not as the person using it.
 
 <ReadMore>
   Read more about building a self-hosted app in the [Quick Start](/developer/crowdin-apps-quick-start/).

--- a/src/content/sidebars/developer.ts
+++ b/src/content/sidebars/developer.ts
@@ -9,6 +9,7 @@ export default [
     items: [
       { slug: path('crowdin-apps-about') },
       { slug: path('crowdin-apps-quick-start') },
+      { slug: path('crowdin-apps-serverless') },
       { slug: path('crowdin-apps-app-descriptor') },
       { slug: path('crowdin-apps-js') },
       { slug: path('crowdin-apps-installation') },


### PR DESCRIPTION
Surfaces the new Crowdin Serverless Apps SDK in the Developer Portal and documents making API requests from apps.

**Serverless apps (positioning)**
- New "Serverless Apps" page + sidebar entry
- "Choose How to Build" section on the About page comparing serverless and self-hosted apps
- Quick Start and About intro scoped to the self-hosted path, with cross-links to the serverless page

**Crowdin Apps JS**
- New "Making API Requests" section: `AP.apiRequest` and the typed client via `@crowdin/apps-api-adapter`