### PR TITLE
chore: configure Dependabot version updates with cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Enable weekly npm version updates with a 3-day cooldown so proposed versions clear pnpm's 24h minimumReleaseAge policy, and group minor/patch bumps into a single PR.