### PR TITLE
docs(developer): add missing scopes to Understanding Scopes

### DIFF
--- a/src/content/docs/developer/security/understanding-scopes.mdx
+++ b/src/content/docs/developer/security/understanding-scopes.mdx
@@ -91,6 +91,12 @@ The scopes you specify for the OAuth app on Crowdin will be shown to the users o
     <td>Grants access to manage the files with the project terminology.</td>
   </tr>
   <tr>
+    <td>Style guides</td>
+    <td><code>style-guide</code></td>
+    <td>Read and Write,<br/>Read only</td>
+    <td>Grants access to manage style guides and assign them to projects.</td>
+  </tr>
+  <tr>
     <td>Users</td>
     <td><code>user</code></td>
     <td>Read and Write,<br/>Read only</td>
@@ -143,6 +149,18 @@ The scopes you specify for the OAuth app on Crowdin will be shown to the users o
     <td><code>ai.fine-tuning</code></td>
     <td>Read and Write,<br/>Read only</td>
     <td>Grants access to manage the fine-tuning of AI prompts.</td>
+  </tr>
+  <tr>
+    <td>AI Translate</td>
+    <td><code>ai.translate</code></td>
+    <td>Read and Write</td>
+    <td>Grants access to AI translation of strings and files, including file translation status and results. All AI Translate endpoints require write access.</td>
+  </tr>
+  <tr>
+    <td>AI Request logs</td>
+    <td><code class="whitespace-nowrap">ai.request-log</code></td>
+    <td>Read only</td>
+    <td>Grants access to get the list of AI request logs, including request details and costs.</td>
   </tr>
   <tr>
     <td>Automations</td>
@@ -223,6 +241,12 @@ The scopes you specify for the OAuth app on Crowdin will be shown to the users o
     <td>Grants access to get screenshots list, add, get, replace, and delete screenshots, ability to access and modify screenshot tags.</td>
   </tr>
   <tr>
+    <td>Context Advisor</td>
+    <td><code>project.advisor</code></td>
+    <td>Read and Write,<br/>Read only</td>
+    <td>Grants access to run Context Advisor checks and to get and update the resulting insights.</td>
+  </tr>
+  <tr>
     <td>Security logs</td>
     <td><code>security-log</code></td>
     <td>Read only</td>
@@ -250,5 +274,5 @@ The scopes you specify for the OAuth app on Crowdin will be shown to the users o
 </table>
 
 <Aside type="caution">
-  The Vendors, Clients, Translation status, AI Proxy, Security logs, Organization, Custom Spellcheckers, and External QA Checks scopes are read-only by default and cannot be edited.
+  The Vendors, Clients, Translation status, AI Proxy, AI Request logs, Security logs, Organization, Custom Spellcheckers, and External QA Checks scopes are read-only by default and cannot be edited.
 </Aside>


### PR DESCRIPTION
Document four scopes that were missing from the available scopes table:

- style-guide
- ai.translate
- ai.request-log
- project.advisor

Also list AI Request logs among the read-only scopes.