### PR TITLE
docs(developer): remove automation scopes from Understanding Scopes

### DIFF
--- a/src/content/docs/developer/security/understanding-scopes.mdx
+++ b/src/content/docs/developer/security/understanding-scopes.mdx
@@ -163,24 +163,6 @@ The scopes you specify for the OAuth app on Crowdin will be shown to the users o
     <td>Grants access to get the list of AI request logs, including request details and costs.</td>
   </tr>
   <tr>
-    <td>Automations</td>
-    <td><code>automation</code></td>
-    <td>Read and Write,<br/>Read only</td>
-    <td>Crowdin Enterprise only. Grants access to manage automation rules and rule executions.</td>
-  </tr>
-  <tr>
-    <td>Automation rules</td>
-    <td><code>automation.rule</code></td>
-    <td>Read and Write,<br/>Read only</td>
-    <td>Crowdin Enterprise only. Grants access to manage automation rules.</td>
-  </tr>
-  <tr>
-    <td>Automation rule executions</td>
-    <td><code>automation.rule.execution</code></td>
-    <td>Read and Write,<br/>Read only</td>
-    <td>Crowdin Enterprise only. Grants access to manage automation rule executions.</td>
-  </tr>
-  <tr>
     <td>Projects</td>
     <td><code>project</code></td>
     <td>Read and Write,<br/>Read only</td>


### PR DESCRIPTION
Drop the automation, automation.rule, and automation.rule.execution rows from the available scopes table.