### PR TITLE
docs(figma): document translating Figma variables and refresh the plugin article

### DIFF
--- a/src/content/docs/crowdin/integrations/figma.mdx
+++ b/src/content/docs/crowdin/integrations/figma.mdx
@@ -131,7 +131,7 @@ You can add strings that are already used in the designs.
       * Select the **Skip locked elements** to exclude any locked text elements from being sent for translation. This is useful when you want certain text to remain visible on screenshots for context but not be added to Crowdin as a source string. <Image src={addStrings} alt="Figma Plugin Add String" class="width-2xl" />
   5. *(Optional)* Configure string settings. You can adjust settings for individual strings or apply bulk settings to all strings at once:
       * **Individual String Settings**: Click <Icon name="mdi:cog-outline" class="inline-icon" /> next to a specific string in the list to update its context or set the maximum length of the translated text for that row.
-      * **Multiple Strings Settings**: Click <Icon name="mdi:cog-outline" class="inline-icon" /> in the upper right corner, above the string list, to open settings for all selected strings. Here, you can configure the **Max. Length Correction (%)** option. This feature automatically sets a maximum character limit by adding a specified percentage to the original string's length (for example, entering "20" means a 100-character string will have a max length of 120). This is particularly useful for accommodating text expansion during translation, helping you avoid text truncation in the localized UI. Any bulk settings applied here can still be overridden per string using the individual string settings.
+      * **String Defaults**: Click <Icon name="mdi:cog-outline" class="inline-icon" /> in the upper right corner, above the string list, to open the default settings applied to all strings in the list. Here, you can configure the [key naming pattern](#key-naming-pattern-settings) and the **Max. Length Correction (%)** option. The latter automatically sets a maximum character limit by adding a specified percentage to the original string's length (for example, entering "20" means a 100-character string will have a max length of 120). This is particularly useful for accommodating text expansion during translation, helping you avoid text truncation in the localized UI. The changes take effect once you click **Apply** and can still be overridden per string using the individual string settings.
   6. Once all the needed strings are selected and configured, click **Next**.
   7. In the next dialog page, select the preferred options:
       * **Auto-link existing strings** &ndash; Automatically compare text to existing strings in Crowdin. If there's a match, the text element will be linked to the string in the Crowdin project.
@@ -147,7 +147,7 @@ You can add strings that are already used in the designs.
       * **Keep Translations and Approvals** &ndash; Retains both existing translations and their approval statuses. Ideal for minor typo fixes where the translation remains accurate.
       * **Keep Translations** &ndash; Retains existing translations but removes approval statuses, meaning the translations will need to be reviewed and approved again.
       * **Clear Translations and Approvals** &ndash; Removes all existing translations and approvals. Use this when the meaning of the source text changes significantly, requiring the string to be translated from scratch.
-  10. Click **Submit**.
+  10. Click **Send to Crowdin**.
 </Steps>
 
 #### Understanding the Upload Summary
@@ -177,7 +177,7 @@ You can add strings with plural forms.
   5. Click <Icon name="mdi:cog-outline" class="inline-icon" /> next to the needed string and click **Add plurals**.
   6. In the appeared dialog, fill in the fields for each plural form and click **Save**. Depending on the source language of the connected Crowdin project, there could be a different number of plural forms you should specify.
   7. Once all the needed strings are selected and configured, click **Next**.
-  8. Select the preferred options and the file in Crowdin you want to add the strings to, then click **Submit**.
+  8. Select the preferred options and the file in Crowdin you want to add the strings to, then click **Send to Crowdin**.
 </Steps>
 
 <Aside>
@@ -208,17 +208,24 @@ When [previewing translations](#previewing-strings) for ICU strings in Figma, th
 
 ### Key Naming Pattern Settings
 
-To simplify adding strings from Figma to the Crowdin project, you can set up the desired key naming pattern for the source string identifiers in the plugin settings. The Crowdin plugin for Figma will suggest the string identifiers for new strings based on the selected pattern. While adding new source strings, you can always edit the suggested identifier to the preferred look.
+To simplify adding strings from Figma to the Crowdin project, you can set up the desired key naming pattern for the source string identifiers. The Crowdin plugin for Figma will suggest the string identifiers for new strings based on the selected pattern. While adding new source strings, you can always edit the suggested identifier to the preferred look.
 
 To select the key naming pattern, follow these steps:
 
 <Steps>
   1. Open the Crowdin plugin for Figma.
-  2. Switch to the **Settings** tab.
-  3. In the **Key Naming Pattern** section, select the preferred option from the drop-down menu.
+  2. Select the needed text elements and click <Icon name="mdi:plus" class="inline-icon" /> in the **Strings** tab.
+  3. In the appeared dialog, click <Icon name="mdi:cog-outline" class="inline-icon" /> in the upper right corner, above the string list.
+  4. In the **Key Naming Pattern** section, select the preferred option from the drop-down menu and click **Apply**. The string keys in the list will be regenerated according to the selected pattern.
 </Steps>
 
-Besides the existing patterns, you can configure your own pattern. To use a custom pattern, select the **Custom key naming pattern** option from the drop-down list and specify your pattern in the **Custom Key Naming Pattern** field.
+Besides the existing patterns, you can configure your own pattern. To use a custom pattern, select the **Custom key naming pattern** option from the drop-down list and specify your pattern in the **Custom Key Naming Pattern** field. Type `[%` in the field to see the available placeholders.
+
+Additionally, you can select **Use camelCase key naming style** to generate keys in camelCase (e.g., `siteFooter`) instead of the default snake_case (e.g., `site_footer`).
+
+<Aside>
+  Key naming settings were previously located in the plugin's **Settings** tab. They are now configured directly in the dialogs where you send strings to Crowdin, separately for the **Strings** and **Variables** tabs.
+</Aside>
 
 ### Uploading Tagged Screenshots to Crowdin
 
@@ -349,6 +356,42 @@ To localize your designs in Figma Buzz, follow these steps:
   4. Once translations are ready, go to the **Crowdin to Figma** section and click **Selected Assets**. Select the target languages you want to import on the next screen and click **Import Selected Assets** to apply the translations.
 </Steps>
 
+## Translating Figma Variables :badge[New]{variant=success}
+
+If your designs use [Figma variables](https://help.figma.com/hc/en-us/articles/15339657135383-Guide-to-variables-in-Figma) for UI copy, you can translate String variables directly in the **Variables** tab. In a variable collection, the default mode holds the source text, and each target language gets its own mode: the plugin sends the default-mode values to Crowdin as source strings and writes translations back into the language modes. Designs that use these variables can then be switched to any translated language natively in Figma.
+
+The plugin works with local String variable collections. Color, Number, and Boolean variables, library variables, extended collections, and values that are aliases to other variables are skipped.
+
+Text layers bound to a variable can still be sent as separate strings from the **Strings** tab, but their text is read-only in the string list, and previewing translations in place won't change them &ndash; use **Preview in duplicated page** to see the translated text.
+
+### Sending Variables to Crowdin
+
+<Steps>
+  1. Open the Crowdin plugin for Figma.
+  2. Switch to the **Variables** tab.
+  3. Select the variable collections you want to translate and click **Send to Crowdin**.
+  4. Review the list of strings to be added. String keys are generated from the collection, group, and variable names. You can edit each string's key and context individually or configure the key naming pattern for all of them by clicking <Icon name="mdi:cog-outline" class="inline-icon" /> above the list.
+  5. Click **Next**, select the preferred options, and click **Send to Crowdin**.
+</Steps>
+
+If you select the **Send screenshots** option, screenshots for translators' reference are generated from the current page's text layers that use the sent variables.
+
+### Syncing Translations into Modes
+
+The **Sync Translations** button stays disabled until the selected collections contain variables linked to Crowdin strings, so send them to Crowdin first.
+
+<Steps>
+  1. In the **Variables** tab, select the needed collections and click **Sync Translations**.
+  2. Select the target languages you want to sync. By default, **All languages** is selected.
+  3. Click **Sync Translations**.
+</Steps>
+
+For each selected language, the plugin creates or updates a mode named after the Crowdin language code (e.g., `uk`, `zh-CN`) in the selected collections and fills it with translations. The collection's default mode is never overwritten and always holds your source text.
+
+<Aside>
+  The number of modes per collection depends on your Figma plan. Languages that exceed the plan limit are skipped and reported after the sync.
+</Aside>
+
 ## Pseudo-localization
 
 Even before translations are completed, you can test whether your application is ready to be localized using pseudo-localization. This feature allows you to simulate how the application's UI will look with different languages to check whether the source strings should be modified before the project localization starts.
@@ -404,7 +447,7 @@ The integration of Crowdin for Figma plugin with Dev Mode extends the functional
 * Explore string details, including file, key, context, and labels.
 * Quickly copy string keys for efficient workflow.
 
-Features not available in Dev Mode: adding new strings to Crowdin, linking strings, sending screenshots, previewing translations, editing, hiding, or deleting strings.
+Features not available in Dev Mode: adding new strings to Crowdin, linking strings, sending screenshots, previewing translations, editing, hiding, or deleting strings. The **Variables** tab is also unavailable in Dev Mode.
 
 ### Using Crowdin for Figma Plugin in Dev Mode
 

--- a/src/content/docs/crowdin/integrations/figma.mdx
+++ b/src/content/docs/crowdin/integrations/figma.mdx
@@ -223,10 +223,6 @@ Besides the existing patterns, you can configure your own pattern. To use a cust
 
 Additionally, you can select **Use camelCase key naming style** to generate keys in camelCase (e.g., `siteFooter`) instead of the default snake_case (e.g., `site_footer`).
 
-<Aside>
-  Key naming settings were previously located in the plugin's **Settings** tab. They are now configured directly in the dialogs where you send strings to Crowdin, separately for the **Strings** and **Variables** tabs.
-</Aside>
-
 ### Uploading Tagged Screenshots to Crowdin
 
 When [adding source strings used in the designs](#adding-source-strings-from-figma-to-crowdin), make sure to keep **Send screenshots** selected. As a result, the Crowdin plugin for Figma will upload screenshots along with the source strings.
@@ -370,8 +366,9 @@ Text layers bound to a variable can still be sent as separate strings from the *
   1. Open the Crowdin plugin for Figma.
   2. Switch to the **Variables** tab.
   3. Select the variable collections you want to translate and click **Send to Crowdin**.
-  4. Review the list of strings to be added. String keys are generated from the collection, group, and variable names. You can edit each string's key and context individually or configure the key naming pattern for all of them by clicking <Icon name="mdi:cog-outline" class="inline-icon" /> above the list.
-  5. Click **Next**, select the preferred options, and click **Send to Crowdin**.
+  4. Review the list of strings to be added. String keys are generated from the collection, group, and variable names. You can edit each string's key and context individually or click <Icon name="mdi:cog-outline" class="inline-icon" /> above the list to open the same **String Defaults** panel as in the **Strings** tab, where you can configure the [key naming pattern](#key-naming-pattern-settings) and the **Max. Length Correction (%)** option.
+  5. Click **Next** and select the preferred options &ndash; the same ones as when [adding source strings from Figma to Crowdin](#adding-source-strings-from-figma-to-crowdin).
+  6. From the **File** drop-down menu, select the file in Crowdin to which you want to add the strings, and click **Send to Crowdin**. The button stays disabled until a file is selected.
 </Steps>
 
 If you select the **Send screenshots** option, screenshots for translators' reference are generated from the current page's text layers that use the sent variables.
@@ -386,7 +383,7 @@ The **Sync Translations** button stays disabled until the selected collections c
   3. Click **Sync Translations**.
 </Steps>
 
-For each selected language, the plugin creates or updates a mode named after the Crowdin language code (e.g., `uk`, `zh-CN`) in the selected collections and fills it with translations. The collection's default mode is never overwritten and always holds your source text.
+For each selected language, the plugin creates or updates a mode named after the [Crowdin language code](/developer/language-codes/) in the selected collections and fills it with translations. The collection's default mode is never overwritten and always holds your source text.
 
 <Aside>
   The number of modes per collection depends on your Figma plan. Languages that exceed the plan limit are skipped and reported after the sync.

--- a/src/content/docs/enterprise/integrations/figma.mdx
+++ b/src/content/docs/enterprise/integrations/figma.mdx
@@ -223,10 +223,6 @@ Besides the existing patterns, you can configure your own pattern. To use a cust
 
 Additionally, you can select **Use camelCase key naming style** to generate keys in camelCase (e.g., `siteFooter`) instead of the default snake_case (e.g., `site_footer`).
 
-<Aside>
-  Key naming settings were previously located in the plugin's **Settings** tab. They are now configured directly in the dialogs where you send strings to Crowdin Enterprise, separately for the **Strings** and **Variables** tabs.
-</Aside>
-
 ### Uploading Tagged Screenshots to Crowdin
 
 When [adding source strings used in the designs](#adding-source-strings-from-figma-to-crowdin), make sure to keep **Send screenshots** selected. As a result, the Crowdin plugin for Figma will upload screenshots along with the source strings.
@@ -370,8 +366,9 @@ Text layers bound to a variable can still be sent as separate strings from the *
   1. Open the Crowdin plugin for Figma.
   2. Switch to the **Variables** tab.
   3. Select the variable collections you want to translate and click **Send to Crowdin**.
-  4. Review the list of strings to be added. String keys are generated from the collection, group, and variable names. You can edit each string's key and context individually or configure the key naming pattern for all of them by clicking <Icon name="mdi:cog-outline" class="inline-icon" /> above the list.
-  5. Click **Next**, select the preferred options, and click **Send to Crowdin**.
+  4. Review the list of strings to be added. String keys are generated from the collection, group, and variable names. You can edit each string's key and context individually or click <Icon name="mdi:cog-outline" class="inline-icon" /> above the list to open the same **String Defaults** panel as in the **Strings** tab, where you can configure the [key naming pattern](#key-naming-pattern-settings) and the **Max. Length Correction (%)** option.
+  5. Click **Next** and select the preferred options &ndash; the same ones as when [adding source strings from Figma to Crowdin](#adding-source-strings-from-figma-to-crowdin).
+  6. From the **File** drop-down menu, select the file in Crowdin Enterprise to which you want to add the strings, and click **Send to Crowdin**. The button stays disabled until a file is selected.
 </Steps>
 
 If you select the **Send screenshots** option, screenshots for translators' reference are generated from the current page's text layers that use the sent variables.
@@ -386,7 +383,7 @@ The **Sync Translations** button stays disabled until the selected collections c
   3. Click **Sync Translations**.
 </Steps>
 
-For each selected language, the plugin creates or updates a mode named after the Crowdin Enterprise language code (e.g., `uk`, `zh-CN`) in the selected collections and fills it with translations. The collection's default mode is never overwritten and always holds your source text.
+For each selected language, the plugin creates or updates a mode named after the [Crowdin language code](/developer/language-codes/) in the selected collections and fills it with translations. The collection's default mode is never overwritten and always holds your source text.
 
 <Aside>
   The number of modes per collection depends on your Figma plan. Languages that exceed the plan limit are skipped and reported after the sync.

--- a/src/content/docs/enterprise/integrations/figma.mdx
+++ b/src/content/docs/enterprise/integrations/figma.mdx
@@ -54,7 +54,7 @@ To specify your Crowdin Enterprise credentials in Figma, follow these steps:
   1. In the file menu, go to **Plugins > Saved plugins**. Alternatively, right-click the canvas and click **Plugins > Saved plugins**.
   2. Click **Crowdin for Figma**.
   3. Switch to the **Settings** tab.
-  4. Provide your Personal Access Token.
+  4. Provide your **Organization Name** (your organization domain, e.g., *your_organization*) and Personal Access Token.
   5. Click **Connect**.
 </Steps>
 
@@ -131,7 +131,7 @@ You can add strings that are already used in the designs.
       * Select the **Skip locked elements** to exclude any locked text elements from being sent for translation. This is useful when you want certain text to remain visible on screenshots for context but not be added to Crowdin Enterprise as a source string. <Image src={addStrings} alt="Figma Plugin Add String" class="width-2xl" />
   5. *(Optional)* Configure string settings. You can adjust settings for individual strings or apply bulk settings to all strings at once:
       * **Individual String Settings**: Click <Icon name="mdi:cog-outline" class="inline-icon" /> next to a specific string in the list to update its context or set the maximum length of the translated text for that row.
-      * **Multiple Strings Settings**: Click <Icon name="mdi:cog-outline" class="inline-icon" /> in the upper right corner, above the string list, to open settings for all selected strings. Here, you can configure the **Max. Length Correction (%)** option. This feature automatically sets a maximum character limit by adding a specified percentage to the original string's length (for example, entering "20" means a 100-character string will have a max length of 120). This is particularly useful for accommodating text expansion during translation, helping you avoid text truncation in the localized UI. Any bulk settings applied here can still be overridden per string using the individual string settings.
+      * **String Defaults**: Click <Icon name="mdi:cog-outline" class="inline-icon" /> in the upper right corner, above the string list, to open the default settings applied to all strings in the list. Here, you can configure the [key naming pattern](#key-naming-pattern-settings) and the **Max. Length Correction (%)** option. The latter automatically sets a maximum character limit by adding a specified percentage to the original string's length (for example, entering "20" means a 100-character string will have a max length of 120). This is particularly useful for accommodating text expansion during translation, helping you avoid text truncation in the localized UI. The changes take effect once you click **Apply** and can still be overridden per string using the individual string settings.
   6. Once all the needed strings are selected and configured, click **Next**.
   7. In the next dialog page, select the preferred options:
       * **Auto-link existing strings** &ndash; Automatically compare text to existing strings in Crowdin Enterprise. If there's a match, the text element will be linked to the string in the Crowdin Enterprise project.
@@ -147,7 +147,7 @@ You can add strings that are already used in the designs.
       * **Keep Translations and Approvals** &ndash; Retains both existing translations and their approval statuses. Ideal for minor typo fixes where the translation remains accurate.
       * **Keep Translations** &ndash; Retains existing translations but removes approval statuses, meaning the translations will need to be reviewed and approved again.
       * **Clear Translations and Approvals** &ndash; Removes all existing translations and approvals. Use this when the meaning of the source text changes significantly, requiring the string to be translated from scratch.
-  10. Click **Submit**.
+  10. Click **Send to Crowdin**.
 </Steps>
 
 #### Understanding the Upload Summary
@@ -177,7 +177,7 @@ You can add strings with plural forms.
   5. Click <Icon name="mdi:cog-outline" class="inline-icon" /> next to the needed string and click **Add plurals**.
   6. In the appeared dialog, fill in the fields for each plural form and click **Save**. Depending on the source language of the connected Crowdin Enterprise project, there could be a different number of plural forms you should specify.
   7. Once all the needed strings are selected and configured, click **Next**.
-  8. Select the preferred options and the file in Crowdin Enterprise you want to add the strings to, then click **Submit**.
+  8. Select the preferred options and the file in Crowdin Enterprise you want to add the strings to, then click **Send to Crowdin**.
 </Steps>
 
 <Aside>
@@ -208,17 +208,24 @@ When [previewing translations](#previewing-strings) for ICU strings in Figma, th
 
 ### Key Naming Pattern Settings
 
-To simplify adding strings from Figma to the Crowdin Enterprise project, you can set up the desired key naming pattern for the source string identifiers in the plugin settings. The Crowdin plugin for Figma will suggest the string identifiers for new strings based on the selected pattern. While adding new source strings, you can always edit the suggested identifier to the preferred look.
+To simplify adding strings from Figma to the Crowdin Enterprise project, you can set up the desired key naming pattern for the source string identifiers. The Crowdin plugin for Figma will suggest the string identifiers for new strings based on the selected pattern. While adding new source strings, you can always edit the suggested identifier to the preferred look.
 
 To select the key naming pattern, follow these steps:
 
 <Steps>
   1. Open the Crowdin plugin for Figma.
-  2. Switch to the **Settings** tab.
-  3. In the **Key Naming Pattern** section, select the preferred option from the drop-down menu.
+  2. Select the needed text elements and click <Icon name="mdi:plus" class="inline-icon" /> in the **Strings** tab.
+  3. In the appeared dialog, click <Icon name="mdi:cog-outline" class="inline-icon" /> in the upper right corner, above the string list.
+  4. In the **Key Naming Pattern** section, select the preferred option from the drop-down menu and click **Apply**. The string keys in the list will be regenerated according to the selected pattern.
 </Steps>
 
-Besides the existing patterns, you can configure your own pattern. To use a custom pattern, select the **Custom key naming pattern** option from the drop-down list and specify your pattern in the **Custom Key Naming Pattern** field.
+Besides the existing patterns, you can configure your own pattern. To use a custom pattern, select the **Custom key naming pattern** option from the drop-down list and specify your pattern in the **Custom Key Naming Pattern** field. Type `[%` in the field to see the available placeholders.
+
+Additionally, you can select **Use camelCase key naming style** to generate keys in camelCase (e.g., `siteFooter`) instead of the default snake_case (e.g., `site_footer`).
+
+<Aside>
+  Key naming settings were previously located in the plugin's **Settings** tab. They are now configured directly in the dialogs where you send strings to Crowdin Enterprise, separately for the **Strings** and **Variables** tabs.
+</Aside>
 
 ### Uploading Tagged Screenshots to Crowdin
 
@@ -349,6 +356,42 @@ To localize your designs in Figma Buzz, follow these steps:
   4. Once translations are ready, go to the **Crowdin to Figma** section and click **Selected Assets**. Select the target languages you want to import on the next screen and click **Import Selected Assets** to apply the translations.
 </Steps>
 
+## Translating Figma Variables :badge[New]{variant=success}
+
+If your designs use [Figma variables](https://help.figma.com/hc/en-us/articles/15339657135383-Guide-to-variables-in-Figma) for UI copy, you can translate String variables directly in the **Variables** tab. In a variable collection, the default mode holds the source text, and each target language gets its own mode: the plugin sends the default-mode values to Crowdin Enterprise as source strings and writes translations back into the language modes. Designs that use these variables can then be switched to any translated language natively in Figma.
+
+The plugin works with local String variable collections. Color, Number, and Boolean variables, library variables, extended collections, and values that are aliases to other variables are skipped.
+
+Text layers bound to a variable can still be sent as separate strings from the **Strings** tab, but their text is read-only in the string list, and previewing translations in place won't change them &ndash; use **Preview in duplicated page** to see the translated text.
+
+### Sending Variables to Crowdin
+
+<Steps>
+  1. Open the Crowdin plugin for Figma.
+  2. Switch to the **Variables** tab.
+  3. Select the variable collections you want to translate and click **Send to Crowdin**.
+  4. Review the list of strings to be added. String keys are generated from the collection, group, and variable names. You can edit each string's key and context individually or configure the key naming pattern for all of them by clicking <Icon name="mdi:cog-outline" class="inline-icon" /> above the list.
+  5. Click **Next**, select the preferred options, and click **Send to Crowdin**.
+</Steps>
+
+If you select the **Send screenshots** option, screenshots for translators' reference are generated from the current page's text layers that use the sent variables.
+
+### Syncing Translations into Modes
+
+The **Sync Translations** button stays disabled until the selected collections contain variables linked to Crowdin Enterprise strings, so send them to Crowdin Enterprise first.
+
+<Steps>
+  1. In the **Variables** tab, select the needed collections and click **Sync Translations**.
+  2. Select the target languages you want to sync. By default, **All languages** is selected.
+  3. Click **Sync Translations**.
+</Steps>
+
+For each selected language, the plugin creates or updates a mode named after the Crowdin Enterprise language code (e.g., `uk`, `zh-CN`) in the selected collections and fills it with translations. The collection's default mode is never overwritten and always holds your source text.
+
+<Aside>
+  The number of modes per collection depends on your Figma plan. Languages that exceed the plan limit are skipped and reported after the sync.
+</Aside>
+
 ## Pseudo-localization
 
 Even before translations are completed, you can test whether your application is ready to be localized using pseudo-localization. This feature allows you to simulate how the application's UI will look with different languages to check whether the source strings should be modified before the project localization starts.
@@ -404,7 +447,7 @@ The integration of Crowdin for Figma plugin with Dev Mode extends the functional
 * Explore string details, including file, key, context, and labels.
 * Quickly copy string keys for efficient workflow.
 
-Features not available in Dev Mode: adding new strings to Crowdin Enterprise, linking strings, sending screenshots, previewing translations, editing, hiding, or deleting strings.
+Features not available in Dev Mode: adding new strings to Crowdin Enterprise, linking strings, sending screenshots, previewing translations, editing, hiding, or deleting strings. The **Variables** tab is also unavailable in Dev Mode.
 
 ### Using Crowdin for Figma Plugin in Dev Mode
 


### PR DESCRIPTION
Update both the Crowdin and Crowdin Enterprise articles:

- Add a "Translating Figma Variables" section covering supported collections, sending default-mode values to Crowdin, syncing translations into per-language modes, screenshots, and the Figma plan mode limit
- Note that Sync Translations stays disabled until the selected collections have variables linked to Crowdin strings
- Note that text layers bound to a variable are read-only in the string list and unaffected by in-place preview
- Move the key naming pattern instructions from the Settings tab to the String Defaults dialog, and document the camelCase style and custom pattern placeholders
- Describe how duplicated linked elements are treated and the warning shown before updating linked strings
- Replace the stale Submit button label with Send to Crowdin in the add-strings flows
- Mention that the Variables tab is unavailable in Dev Mode