### PR TITLE
docs: document the MDX syntax QA check and rework the QA Checks articles

### DIFF
--- a/src/content/docs/crowdin/project-management/project-settings/qa-checks.mdx
+++ b/src/content/docs/crowdin/project-management/project-settings/qa-checks.mdx
@@ -18,9 +18,9 @@ import qaChecksView from '!/crowdin/project-management/settings/qa_checks_view.p
 import qaChecksDetails from '!/crowdin/project-management/settings/qa_checks_details.png';
 import qaChecksAddToIgnoreList from '!/crowdin/project-management/settings/qa_checks_add_to_ignore_list.png';
 
-The main aim of quality assurance (QA) checks is to help you efficiently handle different language-specific aspects in translations and ensure they are formatted the same way as the source strings and will fit the UI just as well. Some typical QA check issues include missed commas, extra spaces, or typos.
+Quality assurance (QA) checks scan translations for language-specific formatting that doesn't match the source string or won't fit the UI. Typical issues are missed commas, extra spaces, and typos.
 
-With QA checks, issues that should be fixed are highlighted in the Editor. QA checks help to detect some common mistakes easily and quickly. It's recommended to review and resolve all QA check issues before building your project and downloading translations.
+Crowdin highlights the issues it finds in the Editor, so review and resolve them before you build the project and download translations.
 
 <Image src={qaChecksInEditor} alt="QA Checks in Editor" />
 
@@ -28,7 +28,7 @@ With QA checks, issues that should be fixed are highlighted in the Editor. QA ch
   QA issue indicators may vary depending on the active [Editor mode and layout](/online-editor/#editor-modes).
 </Aside>
 
-In the **QA Checks** section, you can manage the types of QA issues to be highlighted in the Editor during the translation process.
+In the **QA Checks** section, you choose which types of QA issues Crowdin highlights during translation.
 
 ## Configure QA Checks
 
@@ -38,49 +38,55 @@ By default, QA checks are enabled. To select the needed QA checks in your projec
   1. Open your project and go to **Settings > QA Checks**.
   2. Ensure that **Enable QA Checks** is selected. <Image src={qaChecksSettings} alt="QA Check Settings" />
   3. Select the QA check types according to your preferences.
-  4. For each selected QA check type, choose whether it should be possible to save translations with QA issues by selecting one of two options: **Error** and **Warning**.
-     * **Warning** &ndash; translators are notified about QA issues with suggestions for fixes, but they can still save the translation using the **Save anyway** button.
-     * **Error** &ndash; translators are notified about QA issues with suggestions for fixes, and they cannot save the translation until all issues are resolved.
+  4. For each selected QA check type, choose whether translations with QA issues can be saved: **Error** or **Warning**.
+     * **Warning**: Translators see the QA issue along with suggestions for fixes and can still save the translation with **Save anyway**.
+     * **Error**: Translators see the QA issue along with suggestions for fixes and can save the translation only after resolving it.
   5. Scroll down to the bottom of the QA Checks list and click **Save**. <Image src={qaSaveSettings} alt="QA Checks Save Settings" />
 </Steps>
 
-Once enabled, QA checks will work in the background and scan the translations for potential QA issues.
+A few checks come with a fixed setting:
+
+* **Duplicate translation**, **FTL syntax**, and **MDX syntax** are always enabled and always applied as an **Error**.
+* **ICU syntax** is always enabled, and you choose whether it's applied as an **Error** or a **Warning**.
+* **Spelling mistakes**, **AI-powered check**, and **Outdated translation** are always applied as a **Warning**, and you choose whether they're enabled.
+
+Enabled checks run in the background and scan the translations for potential QA issues.
 
 ## Revalidate QA Checks
 
-Use the **Revalidate** button to re-run enabled QA checks for all project translations and update issue statuses. This is useful after modifying settings, AI prompts, or terminology.
+Use the **Revalidate** button to re-run enabled QA checks for all project translations and update issue statuses. Use it after you change settings, AI prompts, or terminology.
 
 <Aside>
   The **Revalidate** button is only available when at least one supported QA check category is active (**Consistent terminology** or **AI-powered check**).
 </Aside>
 
-Once revalidation starts, the button is disabled and a **Cancel** button appears. When the process is complete, a confirmation notification is shown.
+Once revalidation starts, the button is disabled and a **Cancel** button appears. Crowdin shows a notification when the process is complete.
 
 ## QA Check Parameters
 
-**Empty translation** &ndash; strings that lack translation.
+**Empty translation**: The translation is empty while the source string isn't, or the source string is empty while the translation isn't.
 
-**Length issues** &ndash; translated strings that are longer than the limit of characters you set.
+**Length issues**: The translation is longer than the character limit set for the string.
 
 <Aside type="tip">
-  To set character limits for specific strings, go to **Sources > Strings**. Click **Edit** on the needed string and set the max. length. This means that translators will be notified that a translation for the particular string can't be longer than the specified limit. This is useful when the space for the given text is limited.
+  To set a character limit for a specific string, go to **Sources > Strings**, click **Edit** on the needed string, and set the max. length. Translators then see that the translation for that string can't be longer than the limit, which helps when the space for the text is limited.
 </Aside>
 
-**Tags mismatch** &ndash; strings containing HTML tags might lack some opening or closing tags in translations.
+**Tags mismatch**: The HTML tags in the translation don't match the ones in the source string, or their `id` attributes or CDATA sections differ.
 
-**Spaces mismatch** &ndash; multiple spaces in a row, missing spaces.
+**Spaces mismatch**: The spaces in the translation don't match the ones in the source string, including leading and trailing spaces and newlines, repeated spaces, spaces around special characters, and non-breaking spaces.
 
-**Variables mismatch** &ndash; placeholders that lack some parts of code or have the odd ones.
+**Variables mismatch**: The placeholders in the translation don't match the ones in the source string.
 
-**Punctuation mismatch** &ndash; punctuation mistakes or differences in the punctuation marks.
+**Punctuation mismatch**: The punctuation marks in the translation don't match the ones in the source string, including the spacing before and after them.
 
-**Character case mismatch** &ndash; lower or upper case used differently in source and translated strings.
+**Character case mismatch**: The character case in the translation doesn't match the source string, either at the start of the string or in several capitalized characters in a row.
 
-**Special characters mismatch** &ndash; new paragraphs, currency signs, and other special characters used differently in source and translated strings.
+**Special characters mismatch**: The special characters in the translation don't match the ones in the source string, such as brackets, quotes, markup entities, new paragraphs, and currency signs.
 
-**“Incorrect translation” issues** &ndash; created issues with the "current translation is wrong" tag.
+**"Incorrect translation" issues**: The translation has an open issue that a project member reported with the **Current translation is wrong** type.
 
-**Spelling mistakes** &ndash; words that aren’t present in the dictionaries Crowdin supports.
+**Spelling mistakes**: The translation contains words that aren't present in the dictionaries Crowdin supports.
 
 <Aside type="caution" title="Limitations">
   Currently available for specific languages only.
@@ -89,29 +95,31 @@ Once revalidation starts, the button is disabled and a **Cancel** button appears
   </details>
 </Aside>
 
-**ICU syntax** &ndash; the correct usage of ICU message syntax in translations.
+**ICU syntax**: The translation breaks the ICU message syntax, is missing the `other` plural form, or uses a different structure than the source string.
 
-**Consistent terminology** &ndash; checks whether the source words are translated accordingly to the respective glossary terms.
+**Consistent terminology**: The translation doesn't use the glossary term for a source word, or uses a term marked **not recommended** or **obsolete** in the glossary.
 
 <Aside type="caution" title="Limitations">
   Currently available for English, German, Spanish, French, Italian, Dutch, Norwegian, Norwegian Bokmal, Polish, Russian, Swedish, Ukrainian, Japanese, Korean, Chinese Simplified, and Turkish.
 </Aside>
 
-**Duplicate translation** &ndash; translations that duplicate already existing translations.
+**Duplicate translation**: The translation duplicates an already existing translation.
 
-**FTL syntax** &ndash; the correct usage of the FTL syntax in translations.
+**FTL syntax**: In FTL files, the translation breaks the FTL syntax, or it adds or drops the placeholders and references the source string uses.
 
-**Android syntax** &ndash; the correct usage of the Android syntax in translations.
+**Android syntax**: The translation doesn't keep the placeholder tags (`<xliff:g>`) that the source string uses.
 
-**Numbers mismatch** &ndash; checks for inconsistencies or missing numbers between the source and translations.
+**Numbers mismatch**: The numbers in the translation don't match the ones in the source string or are missing from it.
 
-**AI-powered check** &ndash; uses AI to detect translation issues, improving accuracy and ensuring translations meet project-specific quality standards. Requires configuring an AI prompt with defined evaluation criteria.
+**AI-powered check**: The translation doesn't meet the evaluation criteria defined in your AI prompt. Configure the prompt before you enable the check.
 
 <ReadMore>
   Read more about [Configuring AI-powered check](/crowdin-ai/#setting-up-ai-qa-check).
 </ReadMore>
 
-**Outdated translation** &ndash; flags translations that may need to be revised after their corresponding source strings have been modified.
+**Outdated translation**: The translation predates a change to the source string, so it may need to be revised.
+
+**MDX syntax**: In MDX files, a line in the translation starts with `import` or `export`. MDX treats such a line as code instead of text.
 
 ## Spell Checker
 
@@ -119,60 +127,59 @@ The spell checker powers the **Spelling mistakes** QA check for supported langua
 
 ### How the Spell Checker Works
 
-The spell checker does more than catch misspelled words. For supported languages, it can also flag grammar, punctuation, and capitalization issues, though coverage depends on the language.
+Beyond misspelled words, the spell checker flags grammar, punctuation, and capitalization issues for supported languages, though coverage depends on the language.
 
-Spellcheck explanations are shown in the target language you’re translating into, not in your interface language, so they read naturally for that language’s linguists.
+Spellcheck explanations are shown in the target language you're translating into, not in your interface language, so they read naturally for that language's linguists.
 
 ### Spell Checker Ignore List
 
-If your project contains some uncommon words that are not recognized by the Spell checker, you can add them to the Ignore list to exclude them from being checked.
+If your project uses uncommon words that the spell checker doesn't recognize, add them to the Ignore list to exclude them from the check.
 
-This is useful for project-specific terminology, like brand names or proper nouns (e.g., `MyApp`), which you might expect not to be flagged as errors. Since the Spell checker and Glossary are separate features, adding terms to the Glossary does not automatically add them to the Spellcheck ignore list. Adding them here is the correct way to prevent them from being flagged.
+This suits project-specific terminology such as brand names or proper nouns (for example, `MyApp`). The spell checker and the Glossary are separate features, so adding a term to the Glossary doesn't add it to the Ignore list, and the Ignore list is where you exempt it.
 
 <Image src={qaChecksAddToIgnoreList} alt="QA Checks Add to Ignore list" />
 
-To review the words added to the Ignore list for the Spell checker, follow these steps:
+To review the words added to the Ignore list for the spell checker, follow these steps:
 
 <Steps>
   1. Open your project and go to **Settings > QA Checks**.
-  2. Click **Spellcheck Ignore list** at the bottom of the page.
+  2. Click **Spellcheck Ignore List** at the bottom of the page.
 </Steps>
 
-In the opened window you can see the list of words added to the ignore list. You can filter or remove them from the list if necessary.
+The dialog that opens lists the ignored words, where you can filter them or remove them from the list.
 
 ## QA Issue Indicators
 
-When QA checks detect issues, visual indicators appear across the project interface to help you quickly spot and navigate to translation quality problems.
+When QA checks detect issues, indicators appear across the project interface so you can find the strings that need attention.
 
 ### QA Status Options
 
-<span>OFF</span> &ndash; when it's not enabled.
+The QA check status shows one of the following:
 
-<Badge text="IN PROGRESS" variant="caution" /> &ndash; while it’s working.
-
-<Badge text="NO ISSUES" variant="success" /> &ndash; when no issues are found.
-
-<Badge text="ISSUES FOUND" variant="danger" /> &ndash; when issues are found.
+* <span>OFF</span>: QA checks aren't enabled.
+* <Badge text="IN PROGRESS" variant="caution" />: The check is running.
+* <Badge text="NO ISSUES" variant="success" />: The check found no issues.
+* <Badge text="ISSUES FOUND" variant="danger" />: The check found issues.
 
 ### Viewing Issue Details
 
-When the QA check status is <Badge text="ISSUES FOUND" variant="danger" />, it appears in the **Details** panel on the right side of the project Dashboard. Click on it to reveal two action buttons:
+The <Badge text="ISSUES FOUND" variant="danger" /> status appears in the **Details** panel on the right side of the project Dashboard. Click it to reveal two action buttons:
 
-- **View Issues** &ndash; expands the language row on the Dashboard to show the number of suggestions with QA issues.
-- **Settings** &ndash; takes you directly to **Settings > QA Checks**.
+* **View Issues**: Expands the language row on the Dashboard to show the number of suggestions with QA issues.
+* **Settings**: Takes you directly to **Settings > QA Checks**.
 
 <Image src={qaChecksView} alt="QA Checks View" />
 
-In the expanded language row, click the **N suggestions with QA issues** link to open the Editor with the QA issues filter applied.
+In the expanded language row, click **N suggestions with QA issues** to open the Editor with the QA issues filter applied.
 
 <Image src={qaChecksDetails} alt="QA Checks Details" />
 
-In the Editor, you can review strings with QA issues in the [Side-by-Side mode](/online-editor/#side-by-side-mode). You can approve the existing translations if they are correct, or make changes and then approve them.
+In the Editor, review the strings with QA issues in [Side-by-Side mode](/online-editor/#side-by-side-mode). Approve the existing translations if they are correct, or make changes and then approve them.
 
 ### Per-Language Indicators
 
-Languages with unresolved QA issues are marked with a <Badge text="QA" variant="danger" /> indicator on the project Dashboard. This is an informational indicator that shows at a glance which languages contain unresolved QA issues.
+Languages with unresolved QA issues are marked with a <Badge text="QA" variant="danger" /> indicator on the project Dashboard, so you can see at a glance which languages contain them.
 
 ### Per-File Indicators
 
-You can also identify files with QA issues directly on the language page. Any file containing unresolved QA issues is marked with a <Badge text="QA" variant="danger" /> indicator. This is an informational indicator that shows at a glance which files contain unresolved QA issues. Hover over the indicator to see the number of issues found in that file.
+Files with unresolved QA issues are marked with a <Badge text="QA" variant="danger" /> indicator on the language page. Hover over the indicator to see the number of issues found in that file.

--- a/src/content/docs/developer/api/croql.mdx
+++ b/src/content/docs/developer/api/croql.mdx
@@ -645,6 +645,7 @@ CroQL can be used in the following contexts: source string context, translation 
       "has numbers mismatch qa issues": false,
       "has ai qa issues": false,
       "has outdated translation qa issues": false,
+      "has mdx syntax qa issues": false,
       "has custom qa issues": false,
       "rating": 1,
       "approvalsCount": 1
@@ -1154,6 +1155,13 @@ CroQL can be used in the following contexts: source string context, translation 
     <td>
       <p><strong>Type:</strong> <code>boolean</code></p>
       <p><strong>Description:</strong> The source string has outdated translation QA issues.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>has mdx syntax qa issues</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>boolean</code></p>
+      <p><strong>Description:</strong> The source string has MDX syntax QA issues.</p>
     </td>
   </tr>
   <tr>

--- a/src/content/docs/enterprise/project-management/project-settings/qa-checks.mdx
+++ b/src/content/docs/enterprise/project-management/project-settings/qa-checks.mdx
@@ -16,9 +16,9 @@ import qaChecksInEditor from '!/crowdin/project-management/settings/qa_checks_in
 import qaChecksSettings from '!/enterprise/project-management/settings/qa_checks_settings.png';
 import qaChecksAddToIgnoreList from '!/crowdin/project-management/settings/qa_checks_add_to_ignore_list.png';
 
-The main aim of quality assurance (QA) checks is to help you efficiently handle different language-specific aspects in translations and ensure they are formatted the same way as the source strings and will fit the UI just as well. Some typical QA check issues include missed commas, extra spaces, or typos.
+Quality assurance (QA) checks scan translations for language-specific formatting that doesn't match the source string or won't fit the UI. Typical issues are missed commas, extra spaces, and typos.
 
-With QA checks, issues that should be fixed will be highlighted on the Proofread workflow step. QA checks help to detect some common mistakes easily and quickly. It's recommended to review and resolve all QA check issues before building your project and downloading translations.
+Crowdin Enterprise highlights the issues it finds on the Proofread workflow step, so review and resolve them before you build the project and download translations.
 
 <Image src={qaChecksInEditor} alt="QA Checks in Editor" />
 
@@ -26,7 +26,7 @@ With QA checks, issues that should be fixed will be highlighted on the Proofread
   QA issue indicators may vary depending on the active [Editor mode and layout](/enterprise/online-editor/#editor-modes).
 </Aside>
 
-In the **Quality Assurance** section, you can manage the types of QA issues to be highlighted in the Editor during the translation process.
+In the **Quality Assurance** section, you choose which types of QA issues Crowdin Enterprise highlights during translation.
 
 ## Configure QA Checks
 
@@ -35,18 +35,25 @@ By default, QA checks are enabled. To select the needed QA checks in your projec
 <Steps>
   1. Open your project and go to **Settings > Quality assurance**.
   2. Select the QA check types according to your preferences.
-  3. For each selected QA check type, choose whether it should be possible to save translations with QA issues by selecting one of two options: **Error** and **Warning**.
+  3. For each selected QA check type, choose whether translations with QA issues can be saved: **Error** or **Warning**.
 </Steps>
 
-**Warning** &ndash; translators are notified about QA issues with suggestions for fixes, but they can still save the translation using the **Save anyway** button.
+**Warning**: Translators see the QA issue along with suggestions for fixes and can still save the translation with **Save anyway**.
 
-**Error** &ndash; translators are notified about QA issues with suggestions for fixes, and they cannot save the translation until all issues are resolved.
+**Error**: Translators see the QA issue along with suggestions for fixes and can save the translation only after resolving it.
 
 <Image src={qaChecksSettings} alt="QA Checks Settings" class="width-2xl"/>
 
+A few checks come with a fixed setting:
+
+* **Duplicate**, **FTL Markup syntax check**, and **MDX Markup syntax check** are always enabled and always applied as an **Error**.
+* **ICU Markup syntax check** is always enabled, and you choose whether it's applied as an **Error** or a **Warning**.
+* **Spelling mistakes**, **AI-powered check**, and **Outdated translation** are always applied as a **Warning**, and you choose whether they're enabled.
+* Custom and external QA checks are always applied as a **Warning**.
+
 Use the **Consider as fixed** option to define how many approvals a translation must have before its QA issues are automatically treated as resolved. When a translation reaches the specified number of approvals, Crowdin Enterprise clears any flagged QA issues for that string.
 
-Once enabled, QA checks will work in the background and scan the translations for potential QA issues.
+Enabled checks run in the background and scan the translations for potential QA issues.
 
 <LinkCard
   title="Custom Quality Assurance Checks"
@@ -56,34 +63,34 @@ Once enabled, QA checks will work in the background and scan the translations fo
 
 ## Revalidate QA Checks
 
-Use the **Revalidate** button to re-run enabled QA checks for all project translations and update issue statuses. This is useful after modifying settings, AI prompts, terminology, or external QA checks.
+Use the **Revalidate** button to re-run enabled QA checks for all project translations and update issue statuses. Use it after you change settings, AI prompts, terminology, or external QA checks.
 
 <Aside>
   The **Revalidate** button is only available when at least one supported QA check category is active (**Consistent terminology**, **AI-powered check**, or **external QA checks**).
 </Aside>
 
-Once revalidation starts, the button is disabled and a **Cancel** button appears. When the process is complete, a confirmation notification is shown.
+Once revalidation starts, the button is disabled and a **Cancel** button appears. Crowdin Enterprise shows a notification when the process is complete.
 
 ## QA Check Parameters
 
-**Omissions** &ndash; strings that lack or have excessive translations.
+**Omissions**: The translation is empty while the source string isn't, or the source string is empty while the translation isn't.
 
 - Source is empty but the translation is not
 - Translation is empty but the source is not
 
-**Translation length limit** &ndash; translations that are longer than the limit of characters you set.
+**Translation length limit**: The translation is longer than the character limit set for the string.
 
 <Aside type="tip">
-  To set character limits for specific strings, go to **Sources > Strings**. Double-click on the needed string and set the max. length. This means that translators will be notified that a translation for the particular string can't be longer than the specified limit. This is useful when the space for the given text is limited.
+  To set a character limit for a specific string, go to **Sources > Strings**, double-click the needed string, and set the max. length. Translators then see that the translation for that string can't be longer than the limit, which helps when the space for the text is limited.
 </Aside>
 
-**Tags** &ndash; strings that use HTML might lack some opening or closing tags in translations.
+**Tags**: The tags in the translation don't match the ones in the source string.
 
 - Inconsistent tags in the source and translation
 - ID attributes consistency
 - CDATA tag consistency
 
-**Spacing** &ndash; multiple spaces in a row, missing spaces.
+**Spacing**: The spaces in the translation don't match the ones in the source string.
 
 - Spaces around special symbols
 - Start and end newline characters
@@ -91,31 +98,31 @@ Once revalidation starts, the button is disabled and a **Cancel** button appears
 - Multiple spaces in succession
 - Non-breaking spaces
 
-**Variables** &ndash; placeholders used in a translation match placeholders used in the source string.
+**Variables**: The placeholders in the translation don't match the ones in the source string.
 
 - Common variables
 - Python, Java, .NET, C/C++, Ruby on Rails, Twig, PHP, Freemaker variable placeholders
 - Custom variables (per request)
 
-**Punctuation** &ndash; punctuation mistakes or differences in the punctuation marks.
+**Punctuation**: The punctuation marks in the translation don't match the ones in the source string.
 
 - Inconsistent punctuation in source and translation
 - Spacing before and after punctuation marks
 
-**Character case** &ndash; the lower or upper case that is used differently in source and translated strings.
+**Character case**: The character case in the translation doesn't match the source string.
 
 - Initial capitalization
 - Unexpected multiple capitalized characters in succession
 
-**Special characters** &ndash; new paragraphs, currency signs, and other special characters that are used differently in translated strings.
+**Special characters**: The special characters in the translation don't match the ones in the source string.
 
 - Bracket consistency
 - Markup language entities
 - Quotes and quote escapes
 
-**Open translation issues by project members** &ndash; shows reported translation issues on the Proofread workflow step.
+**Open translation issues by project members**: The translation has an open issue that a project member reported with the **Current translation is wrong** type, shown on the Proofread workflow step.
 
-**Spelling mistakes** &ndash; underline misspelled words.
+**Spelling mistakes**: The translation contains words that aren't present in the dictionaries Crowdin Enterprise supports.
 
 <Aside type="caution" title="Limitations">
   Currently available for specific languages only.
@@ -124,29 +131,31 @@ Once revalidation starts, the button is disabled and a **Cancel** button appears
   </details>
 </Aside>
 
-**ICU Markup syntax check** &ndash; the correct usage of the ICU message syntax in translations.
+**ICU Markup syntax check**: The translation breaks the ICU message syntax, is missing the `other` plural form, or uses a different structure than the source string.
 
-**Consistent terminology** &ndash; checks whether the source words are translated accordingly to the respective glossary terms.
+**Consistent terminology**: The translation doesn't use the glossary term for a source word, or uses a term marked **not recommended** or **obsolete** in the glossary.
 
 <Aside type="caution" title="Limitations">
   Currently available for English, German, Spanish, French, Italian, Dutch, Norwegian, Norwegian Bokmal, Polish, Russian, Swedish, Ukrainian, Japanese, Korean, Chinese Simplified, and Turkish.
 </Aside>
 
-**Duplicate** &ndash; translations that duplicate already existing translations.
+**Duplicate**: The translation duplicates an already existing translation.
 
-**FTL Markup syntax check** &ndash; the correct usage of the FTL syntax in translations.
+**FTL Markup syntax check**: In FTL files, the translation breaks the FTL syntax, or it adds or drops the placeholders and references the source string uses.
 
-**Android Markup syntax check** &ndash; the correct usage of the Android syntax in translations.
+**Android Markup syntax check**: The translation doesn't keep the placeholder tags (`<xliff:g>`) that the source string uses.
 
-**Numbers mismatch** &ndash; checks for inconsistencies or missing numbers between the source and translations.
+**Numbers mismatch**: The numbers in the translation don't match the ones in the source string or are missing from it.
 
-**AI-powered check** &ndash; uses AI to detect translation issues, improving accuracy and ensuring translations meet project-specific quality standards. Requires configuring an AI prompt with defined evaluation criteria.
+**AI-powered check**: The translation doesn't meet the evaluation criteria defined in your AI prompt. Configure the prompt before you enable the check.
 
 <ReadMore>
   Read more about [Configuring AI-powered check](/enterprise/crowdin-ai/#setting-up-ai-qa-check).
 </ReadMore>
 
-**Outdated translation** &ndash; flags translations that may need to be revised after their corresponding source strings have been modified.
+**Outdated translation**: The translation predates a change to the source string, so it may need to be revised.
+
+**MDX Markup syntax check**: In MDX files, a line in the translation starts with `import` or `export`. MDX treats such a line as code instead of text.
 
 ## Spell Checker
 
@@ -154,48 +163,48 @@ The spell checker powers the **Spelling mistakes** QA check for supported langua
 
 ### How the Spell Checker Works
 
-The spell checker does more than catch misspelled words. For supported languages, it can also flag grammar, punctuation, and capitalization issues, though coverage depends on the language.
+Beyond misspelled words, the spell checker flags grammar, punctuation, and capitalization issues for supported languages, though coverage depends on the language.
 
-Spellcheck explanations are shown in the target language you’re translating into, not in your interface language, so they read naturally for that language’s linguists.
+Spellcheck explanations are shown in the target language you're translating into, not in your interface language, so they read naturally for that language's linguists.
 
 If a [custom spellchecker](/enterprise/organization-settings/#spellcheckers) is installed for a language, it handles the check for that language instead.
 
 ### Spell Checker Ignore List
 
-If your project contains some uncommon words that are not recognized by the Spell checker, you can add them to the Ignore list to exclude them from being checked.
+If your project uses uncommon words that the spell checker doesn't recognize, add them to the Ignore list to exclude them from the check.
 
-This is useful for project-specific terminology, like brand names or proper nouns (e.g., `MyApp`), which you might expect not to be flagged as errors. Since the Spell checker and Glossary are separate features, adding terms to the Glossary does not automatically add them to the Spellcheck ignore list. Adding them here is the correct way to prevent them from being flagged.
+This suits project-specific terminology such as brand names or proper nouns (for example, `MyApp`). The spell checker and the Glossary are separate features, so adding a term to the Glossary doesn't add it to the Ignore list, and the Ignore list is where you exempt it.
 
 <Image src={qaChecksAddToIgnoreList} alt="QA Checks Add to Ignore list" />
 
-To review the words added to the Ignore list for the Spell checker, follow these steps:
+To review the words added to the Ignore list for the spell checker, follow these steps:
 
 <Steps>
   1. Open your project and go to **Settings > Quality assurance**.
   2. Click **Ignore list** on the top right side.
 </Steps>
 
-In the opened window you can see the list of words added to the ignore list. You can filter or remove them from the list if necessary.
+The dialog that opens lists the ignored words, where you can filter them or remove them from the list.
 
 ## QA Issue Indicators
 
-When QA checks detect issues, visual indicators appear across the project interface to help you quickly spot and navigate to translation quality problems.
+When QA checks detect issues, indicators appear across the project interface so you can find the strings that need attention.
 
 ### QA Issues Summary
 
-The project Dashboard and each language page display a summary button showing the total number of unresolved QA issues — **N QA issues for all languages** on the Dashboard, and **N QA issues for [Language]** on the language page.
+The project Dashboard and each language page display a summary button with the total number of unresolved QA issues: **N QA issues for all languages** on the Dashboard, and **N QA issues for [Language]** on the language page.
 
 Clicking the button opens a panel with the following details:
 
 - The total number of unresolved QA issues.
 - The change delta in the format `+N/-N/+N`. Hover over it to see the breakdown: how many issues were created, resolved, and are in progress.
-- **Open in Editor** &ndash; opens the Editor filtered to strings with QA issues.
-- <Icon name="mdi:cog" class="inline-icon" /> &ndash; links directly to [**Settings > Quality Assurance**](#configure-qa-checks).
+- **Open in Editor**: Opens the Editor filtered to strings with QA issues.
+- <Icon name="mdi:cog" class="inline-icon" />: Links directly to [**Settings > Quality Assurance**](#configure-qa-checks).
 
 ### Per-Language Indicators
 
-Languages with unresolved QA issues are marked with a <Icon name="material-symbols:warning" class="inline-icon" /> indicator showing the number of issues on the project Dashboard. This is an informational indicator that shows at a glance which languages contain unresolved QA issues.
+Languages with unresolved QA issues are marked with a <Icon name="material-symbols:warning" class="inline-icon" /> indicator showing the number of issues on the project Dashboard, so you can see at a glance which languages contain them.
 
 ### Per-File Indicators
 
-Files with unresolved QA issues are marked with a <Icon name="material-symbols:warning" class="inline-icon" /> indicator showing the number of issues on the language page. This is an informational indicator that shows at a glance which files contain unresolved QA issues.
+Files with unresolved QA issues are marked with a <Icon name="material-symbols:warning" class="inline-icon" /> indicator showing the number of issues on the language page.


### PR DESCRIPTION
- Add the MDX syntax check to both QA Checks articles and the CroQL field reference
- List the checks that come with a fixed enable and Error/Warning setting
- Rewrite every QA check parameter description in one parallel form
- Normalize term lists to colons, straight quotes, and no em dash