### PR TITLE
docs(developer): mark self-hosted-only fields in the module articles

### DIFF
--- a/src/content/docs/developer/modules/other/custom-mt.mdx
+++ b/src/content/docs/developer/modules/other/custom-mt.mdx
@@ -3,7 +3,6 @@ title: Custom MT Module
 description: Connect custom machine translation engines to Crowdin
 slug: developer/crowdin-apps-module-custom-mt
 sidebar:
-  order: 14
   label: Custom MT
 ---
 

--- a/src/content/docs/developer/modules/ui-modules/chat.mdx
+++ b/src/content/docs/developer/modules/ui-modules/chat.mdx
@@ -73,7 +73,7 @@ For Crowdin Enterprise:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the Crowdin or Crowdin Enterprise UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/context-menu.mdx
+++ b/src/content/docs/developer/modules/ui-modules/context-menu.mdx
@@ -194,7 +194,7 @@ Context menu item opens a new tab with the URL: `baseUrl/options.url`.
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
         <p><strong>Required:</strong> yes</p>
-        <p><strong>Allowed values:</strong> <code>modal</code>, <code>new_tab</code>, <code>redirect</code></p>
+        <p><strong>Allowed values:</strong> <code>modal</code>, <code>new_tab</code> (self-hosted apps only), <code>redirect</code></p>
         <p><strong>Description:</strong> The type of action this module will perform.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/editor-asset-panel.mdx
+++ b/src/content/docs/developer/modules/ui-modules/editor-asset-panel.mdx
@@ -78,7 +78,7 @@ For Crowdin Enterprise:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the module content page that will be embedded in the Editor’s asset panel.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/editor-right-panel.mdx
+++ b/src/content/docs/developer/modules/ui-modules/editor-right-panel.mdx
@@ -98,7 +98,7 @@ For Crowdin Enterprise:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the module content page that will be embedded in the Editor’s right panel.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/editor-translations-panel.mdx
+++ b/src/content/docs/developer/modules/ui-modules/editor-translations-panel.mdx
@@ -84,7 +84,7 @@ For Crowdin Enterprise:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the Crowdin Enterprise UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/integrations.mdx
+++ b/src/content/docs/developer/modules/ui-modules/integrations.mdx
@@ -89,7 +89,7 @@ For Crowdin Enterprise:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the Crowdin Enterprise UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/modal.mdx
+++ b/src/content/docs/developer/modules/ui-modules/modal.mdx
@@ -65,7 +65,7 @@ For Crowdin Enterprise:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/organization-menu-crowdsource.mdx
+++ b/src/content/docs/developer/modules/ui-modules/organization-menu-crowdsource.mdx
@@ -58,7 +58,7 @@ You can grant access to this module to one of the following user categories:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the Crowdin Enterprise UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/organization-menu.mdx
+++ b/src/content/docs/developer/modules/ui-modules/organization-menu.mdx
@@ -63,7 +63,7 @@ You can grant access to this module to one of the following user categories:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the Crowdin Enterprise UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/organization-settings-menu.mdx
+++ b/src/content/docs/developer/modules/ui-modules/organization-settings-menu.mdx
@@ -62,7 +62,7 @@ You can grant access to this module to one of the following user categories:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the settings page of the module that will be integrated into the Crowdin Enterprise UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/overview.mdx
+++ b/src/content/docs/developer/modules/ui-modules/overview.mdx
@@ -114,13 +114,6 @@ UI Modules allow apps to extend the Crowdin user interface, create integrations 
       <td>&nbsp;</td>
     </tr>
     <tr>
-      <td>Custom MT</td>
-      <td><code>custom-mt</code></td>
-      <td>Account/Organization</td>
-      <td>&#10004;</td>
-      <td>&#10004;</td>
-    </tr>
-    <tr>
       <td>Context Menu</td>
       <td><code>context-menu</code></td>
       <td>Configurable</td>

--- a/src/content/docs/developer/modules/ui-modules/profile-menu.mdx
+++ b/src/content/docs/developer/modules/ui-modules/profile-menu.mdx
@@ -67,7 +67,7 @@ You can grant access to this module to one of the following user categories:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the Crowdin UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/profile-settings-menu.mdx
+++ b/src/content/docs/developer/modules/ui-modules/profile-settings-menu.mdx
@@ -60,7 +60,7 @@ You can grant access to this module to one of the following user categories:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the settings page of the module that will be integrated into the Crowdin UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/project-menu-crowdsource.mdx
+++ b/src/content/docs/developer/modules/ui-modules/project-menu-crowdsource.mdx
@@ -70,7 +70,7 @@ For Crowdin Enterprise:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the Crowdin Enterprise UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/project-menu.mdx
+++ b/src/content/docs/developer/modules/ui-modules/project-menu.mdx
@@ -72,7 +72,7 @@ For Crowdin Enterprise:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the Crowdin Enterprise UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/reports.mdx
+++ b/src/content/docs/developer/modules/ui-modules/reports.mdx
@@ -84,7 +84,7 @@ For Crowdin Enterprise:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the Crowdin Enterprise UI.</p>
       </td>
     </tr>

--- a/src/content/docs/developer/modules/ui-modules/tools.mdx
+++ b/src/content/docs/developer/modules/ui-modules/tools.mdx
@@ -89,7 +89,7 @@ For Crowdin Enterprise:
       <td><code>url</code></td>
       <td>
         <p><strong>Type:</strong> <code>string</code></p>
-        <p><strong>Required:</strong> yes</p>
+        <p><strong>Required:</strong> yes (self-hosted apps only)</p>
         <p><strong>Description:</strong> The relative URL to the content page of the module that will be integrated into the Crowdin or Crowdin Enterprise UI.</p>
       </td>
     </tr>

--- a/src/content/docs/zh/developer/modules/other/custom-mt.mdx
+++ b/src/content/docs/zh/developer/modules/other/custom-mt.mdx
@@ -3,7 +3,6 @@ title: Custom MT 模块
 description: 将自定义机器翻译引擎连接到 Crowdin
 slug: developer/crowdin-apps-module-custom-mt
 sidebar:
-  order: 14
   label: 自定义机器翻译
 ---
 


### PR DESCRIPTION
- Scoped the `url` field and the Context Menu `new_tab` type to self-hosted apps
- Moved Custom MT from UI Modules to Other