### PR TITLE
docs(developer): cover both app types across the Crowdin Apps section

### DIFF
--- a/src/content/docs/developer/crowdin-apps/about-crowdin-apps.mdx
+++ b/src/content/docs/developer/crowdin-apps/about-crowdin-apps.mdx
@@ -65,7 +65,7 @@ There are two ways to build a Crowdin app. Serverless apps run on Crowdin infras
 
 If your app combines an interface with server-side logic, build it as a self-hosted app. Self-hosted apps can include UI modules as well.
 
-To build a self-hosted app in a language other than JavaScript or TypeScript, follow the [App Descriptor](/developer/crowdin-apps-app-descriptor/) and [Verifying Requests from Crowdin](/developer/crowdin-apps-security/) references.
+To build a self-hosted app in a language other than JavaScript or TypeScript, follow the [App Descriptor](/developer/crowdin-apps-app-descriptor/) and [Security for Crowdin Apps](/developer/crowdin-apps-security/) references.
 
 ## Explore the Docs
 

--- a/src/content/docs/developer/crowdin-apps/about-crowdin-apps.mdx
+++ b/src/content/docs/developer/crowdin-apps/about-crowdin-apps.mdx
@@ -65,7 +65,7 @@ There are two ways to build a Crowdin app. Serverless apps run on Crowdin infras
 
 If your app combines an interface with server-side logic, build it as a self-hosted app. Self-hosted apps can include UI modules as well.
 
-To build a self-hosted app in a language other than JavaScript or TypeScript, follow the [App Descriptor](/developer/crowdin-apps-app-descriptor/) and [Security for Crowdin Apps](/developer/crowdin-apps-security/) references.
+To build a self-hosted app in a language other than JavaScript or TypeScript, follow the [App Descriptor](/developer/crowdin-apps-app-descriptor/) and [Verifying Requests from Crowdin](/developer/crowdin-apps-security/) references.
 
 ## Explore the Docs
 

--- a/src/content/docs/developer/crowdin-apps/app-descriptor.mdx
+++ b/src/content/docs/developer/crowdin-apps/app-descriptor.mdx
@@ -115,7 +115,7 @@ Specifies the authentication type Crowdin uses when it signs requests to the app
 * **`crowdin_agent`**: Through a dedicated bot user that Crowdin creates when the app is installed, so the app keeps working in projects afterwards, for example on a custom workflow step. The app's API calls are authenticated as that user. Required by the [Workflow Step Type](/developer/crowdin-apps-module-workflow-step-type/#authentication) module.
 
 <ReadMore>
-  Read more about [Verifying Requests from Crowdin](/developer/crowdin-apps-security/).
+  Read more about [Security for Crowdin Apps](/developer/crowdin-apps-security/).
 </ReadMore>
 
 Example:

--- a/src/content/docs/developer/crowdin-apps/app-descriptor.mdx
+++ b/src/content/docs/developer/crowdin-apps/app-descriptor.mdx
@@ -85,20 +85,109 @@ A serverless descriptor has no `baseUrl`, declares UI modules without a `url`, a
 
 ### Fields
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `identifier` | `string` | yes | A unique key to identify the app, 255 characters or fewer. |
-| `name` | `string` | yes | The human-readable name of the app. |
-| `baseUrl` | `string` (`uri`) | yes (self-hosted apps only) | The base URL of the remote app, used for all communication back to it. A descriptor without a `baseUrl` describes a serverless app, which Crowdin hosts and runs. |
-| `bundle` | `object` | no (serverless apps only) | Where Crowdin serves the app from. Set `mode` to `internal` for the bundle uploaded to Crowdin, or to `external` with a `url` that points to a local development server. |
-| `authentication` | `Authentication` | no | The authentication type used when signing requests between Crowdin and the app. Defaults to `none`, which is the type serverless apps use. |
-| `description` | `string` | no | The human-readable description of what the app does. It is visible in the Crowdin UI. |
-| `logo` | `string` (`relativeUri`) | no | The image URL relative to the app's base URL, displayed in the Crowdin UI. |
-| `events` | `Events` | no | Callbacks for app event notifications (self-hosted apps only). |
-| `scopes` | [`string`, … ] | yes | Set of [scopes](/developer/understanding-scopes/) requested by this app. |
-| `modules` | `object` | yes | The list of modules this app provides. Serverless apps provide UI modules. |
-| `default_permissions` | `object` | no | Who can use the app right after installation. `user` accepts `owner`, `managers`, `all`, or `guests`, and `project` accepts `own` or `restricted`. |
-| `stringBasedAvailable` | `boolean` | no | Whether the app's modules are available in string-based projects. In file-based projects they are always available. |
+<table>
+  <colgroup>
+    <col width="20%" />
+    <col width="80%" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><code>identifier</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code></p>
+      <p><strong>Required:</strong> yes</p>
+      <p><strong>Description:</strong> A unique key to identify the app, 255 characters or fewer.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>name</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code></p>
+      <p><strong>Required:</strong> yes</p>
+      <p><strong>Description:</strong> The human-readable name of the app.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>baseUrl</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code> (<code>uri</code>)</p>
+      <p><strong>Required:</strong> yes (self-hosted apps only)</p>
+      <p><strong>Description:</strong> The base URL of the remote app, used for all communication back to it. A descriptor without a <code>baseUrl</code> describes a serverless app, which Crowdin hosts and runs.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>bundle</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>object</code></p>
+      <p><strong>Description:</strong> Serverless apps only. Where Crowdin serves the app from. Set <code>mode</code> to <code>internal</code> for the bundle uploaded to Crowdin, or to <code>external</code> with a <code>url</code> that points to a local development server.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>authentication</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>Authentication</code></p>
+      <p><strong>Description:</strong> The authentication type used when signing requests between Crowdin and the app. Defaults to <code>none</code>, which is the type serverless apps use.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>description</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code></p>
+      <p><strong>Description:</strong> The human-readable description of what the app does. It is visible in the Crowdin UI.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>logo</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code> (<code>relativeUri</code>)</p>
+      <p><strong>Description:</strong> The image URL relative to the app's base URL, displayed in the Crowdin UI.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>events</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>Events</code></p>
+      <p><strong>Description:</strong> Callbacks for app event notifications (self-hosted apps only).</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>scopes</code></td>
+    <td>
+      <p><strong>Type:</strong> [<code>string</code>, … ]</p>
+      <p><strong>Required:</strong> yes</p>
+      <p><strong>Description:</strong> Set of [scopes](/developer/understanding-scopes/) requested by this app.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>modules</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>object</code></p>
+      <p><strong>Required:</strong> yes</p>
+      <p><strong>Description:</strong> The list of modules this app provides. Serverless apps provide UI modules.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code class="whitespace-nowrap">default_permissions</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>object</code></p>
+      <p><strong>Description:</strong> Who can use the app right after installation. <code>user</code> accepts <code>owner</code>, <code>managers</code>, <code>all</code>, or <code>guests</code>, and <code>project</code> accepts <code>own</code> or <code>restricted</code>.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code class="whitespace-nowrap">stringBasedAvailable</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>boolean</code></p>
+      <p><strong>Description:</strong> Whether the app's modules are available in string-based projects. In file-based projects they are always available.</p>
+    </td>
+  </tr>
+  </tbody>
+</table>
 
 <Aside>
   Each app must have a unique `baseUrl`. If you would like to serve multiple apps from the same host, consider adding a path prefix into the `baseUrl`.

--- a/src/content/docs/developer/crowdin-apps/app-descriptor.mdx
+++ b/src/content/docs/developer/crowdin-apps/app-descriptor.mdx
@@ -1,6 +1,6 @@
 ---
 title: App Descriptor
-description: Learn how to define the app descriptor
+description: Declare your app and its modules in a JSON file
 slug: developer/crowdin-apps-app-descriptor
 ---
 
@@ -9,19 +9,19 @@ import { Aside } from '@astrojs/starlight/components';
 import ReadMore from '~/components/ReadMore.astro';
 import integratingCrowdinApps from '~/assets/images/integrating-crowdin-apps.svg';
 
-The app descriptor is one of the essential building blocks of Crowdin apps. The app descriptor is a JSON file (for example, `manifest.json`) that includes general information for the app, as well as the modules that the app wants to operate with or extend.
-
-It describes how the application will work, what resources will be used, etc.
+The app descriptor is a JSON file, usually `manifest.json`, that tells Crowdin what the app is and which modules it adds.
 
 <Image src={integratingCrowdinApps} alt="Crowdin app integration" class="no-shadow" />
 
 <Aside type="tip" title="Interested in developing Crowdin Apps?">
-  Check out our [Crowdin Apps SDK](https://crowdin.github.io/app-project-module/) to create apps in just a few lines of code.
+  Start from one of the SDKs: the [Serverless Apps SDK](/developer/crowdin-apps-serverless/) or the [Crowdin Apps SDK](/developer/crowdin-apps-sdk/).
 </Aside>
 
 ## App Descriptor Structure
 
-The app descriptor is a JSON object with the following structure:
+The app descriptor is a JSON object. A self-hosted app serves it from its own server, and a serverless app keeps it in the project and pushes it to Crowdin with the CLI.
+
+### Self-Hosted App
 
 ```json title="manifest.json"
 {
@@ -57,133 +57,65 @@ The app descriptor is a JSON object with the following structure:
 }
 ```
 
-<table>
-  <colgroup>
-    <col width="20%" />
-    <col width="80%" />
-  </colgroup>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td><code>identifier</code></td>
-    <td>
-      <div><strong>Type:</strong> <code>string</code> (<code>^[a-z0-9-._]+$</code>)</div>
-      <p><strong>Required:</strong> yes</p>
-      <p><strong>Description:</strong> A unique key to identify the app. This identifier must be &lt;= 255 characters.</p>
-      <Aside type="caution">Don't use uppercase in the app identifier.</Aside>
-    </td>
-  </tr>
-  <tr>
-    <td><code>name</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Required:</strong> yes</p>
-      <p><strong>Description:</strong> The human-readable name of the app.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>baseUrl</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code> (<code>uri</code>)</p>
-      <p><strong>Required:</strong> yes</p>
-      <p><strong>Description:</strong> The base URL of the remote app, which is used for all communications back to the app instance.<br/>
-        Once the app is installed in a workspace, the app's baseUrl can’t be changed without uninstalling the app beforehand.</p>
-      <p><strong>This is important:</strong> choose your baseUrl wisely before making your app public.<br/>
-        The baseUrl must start with <code>https://</code> to ensure that all data is sent securely between our cloud instances and your app.</p>
-      <Aside>
-        Each app must have a unique `baseUrl`. If you would like to serve multiple apps from the same host, consider adding a path prefix into the `baseUrl`.
-      </Aside>
-    </td>
-  </tr>
-  <tr>
-    <td><code>authentication</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>Authentication</code></p>
-      <p><strong>Required:</strong> yes</p>
-      <p><strong>Description:</strong> Specifies the authentication type to use when signing requests between the host application and the Crowdin app.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>description</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The human-readable description of what the app does.<br/>
-        The description will be visible in the Crowdin UI.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>logo</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code> (<code>relativeUri</code>)</p>
-      <p><strong>Description:</strong> The image URL relative to the app's base URL which will be displayed in the Crowdin UI.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>events</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>Events</code></p>
-      <p><strong>Description:</strong> Allow the app to register for app event notifications.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>scopes</code></td>
-    <td>
-      <p><strong>Type:</strong> [<code>string</code>, … ]</p>
-      <p><strong>Description:</strong> Set of [scopes](/developer/understanding-scopes/) requested by this app.</p>
-      <div>
-        ```json
-        "scopes": [
-          "project",
-          "tm"
-        ]
-        ```
-      </div>
-    </td>
-  </tr>
-  <tr>
-    <td><code>modules</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>object</code></p>
-      <p><strong>Description:</strong> The list of modules this app provides.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>environments</code></td>
-    <td>
-      <p><strong>Type:</strong> [<code>string</code>, … ]</p>
-      <p><strong>Allowed values:</strong> <code>crowdin</code>, <code>crowdin-enterprise</code></p>
-      <p><strong>Description:</strong> Set of environments where a module could be installed.</p>
-      <div>
-        ```json
-        "environments": [
-          "crowdin-enterprise"
-        ]
-        ```
-      </div>
-    </td>
-  </tr>
-  </tbody>
-</table>
+### Serverless App
+
+A serverless descriptor has no `baseUrl`, declares UI modules without a `url`, and leaves out `events`, which point at URLs on a server of your own.
+
+```json title="manifest.json"
+{
+  "identifier": "your-application-identifier",
+  "name": "Your Application",
+  "description": "Application description",
+  "bundle": {
+    "mode": "internal"
+  },
+  "scopes": [
+    "project"
+  ],
+  "modules": {
+    "project-menu": [
+      {
+        "key": "your-module-key",
+        "name": "Module name"
+      }
+    ]
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `identifier` | `string` | yes | A unique key to identify the app, 255 characters or fewer. |
+| `name` | `string` | yes | The human-readable name of the app. |
+| `baseUrl` | `string` (`uri`) | yes (self-hosted apps only) | The base URL of the remote app, used for all communication back to it. A descriptor without a `baseUrl` describes a serverless app, which Crowdin hosts and runs. |
+| `bundle` | `object` | no (serverless apps only) | Where Crowdin serves the app from. Set `mode` to `internal` for the bundle uploaded to Crowdin, or to `external` with a `url` that points to a local development server. |
+| `authentication` | `Authentication` | no | The authentication type used when signing requests between Crowdin and the app. Defaults to `none`, which is the type serverless apps use. |
+| `description` | `string` | no | The human-readable description of what the app does. It is visible in the Crowdin UI. |
+| `logo` | `string` (`relativeUri`) | no | The image URL relative to the app's base URL, displayed in the Crowdin UI. |
+| `events` | `Events` | no | Callbacks for app event notifications (self-hosted apps only). |
+| `scopes` | [`string`, … ] | yes | Set of [scopes](/developer/understanding-scopes/) requested by this app. |
+| `modules` | `object` | yes | The list of modules this app provides. Serverless apps provide UI modules. |
+| `default_permissions` | `object` | no | Who can use the app right after installation. `user` accepts `owner`, `managers`, `all`, or `guests`, and `project` accepts `own` or `restricted`. |
+| `stringBasedAvailable` | `boolean` | no | Whether the app's modules are available in string-based projects. In file-based projects they are always available. |
+
+<Aside>
+  Each app must have a unique `baseUrl`. If you would like to serve multiple apps from the same host, consider adding a path prefix into the `baseUrl`.
+</Aside>
+
+The `baseUrl` must start with `https://`, and it cannot change after the app is installed without uninstalling the app first, so choose it before you make the app public.
 
 ## Authentication
 
-Specifies the authentication type to use when signing requests from the host application to the Crowdin app. Crowdin Apps support the following types of authentication:
+Specifies the authentication type Crowdin uses when it signs requests to the app:
 
-* using OAuth app (`crowdin_app` value)
-* without OAuth app (`none` value)
-* using a dedicated agent user (`crowdin_agent` value) – required by the [Workflow Step Type](/developer/crowdin-apps-module-workflow-step-type/#authentication) module
-
-In case your Crowdin app requires access to Crowdin API at any time, it’s recommended to use the `crowdin_app`, in other cases feel free to use the `none`. The authentication type `none` grants access to Crowdin API as well as the `crowdin_app`, but only when the Crowdin app is executed on the user side, for example, when the iframe opens.
-
-The `crowdin_agent` type is for apps that keep working in your projects after installation, for example, apps that process strings on a custom workflow step. When such an app is installed, Crowdin creates a dedicated bot user, and the app's API calls are authenticated as that user. Read more about [agent authentication](/developer/crowdin-apps-module-workflow-step-type/#authentication).
+* **`crowdin_app`**: Through an OAuth app. Use it when the app calls the Crowdin API on its own, at any time.
+* **`none`**: Without an OAuth app. The app still reaches the API, but only while it runs on the user side, for example while its iframe is open. Serverless apps use this type.
+* **`crowdin_agent`**: Through a dedicated bot user that Crowdin creates when the app is installed, so the app keeps working in projects afterwards, for example on a custom workflow step. The app's API calls are authenticated as that user. Required by the [Workflow Step Type](/developer/crowdin-apps-module-workflow-step-type/#authentication) module.
 
 <ReadMore>
-  Read more about [Security for Crowdin Apps](/developer/crowdin-apps-security/).
+  Read more about [Verifying Requests from Crowdin](/developer/crowdin-apps-security/).
 </ReadMore>
 
 Example:
@@ -197,49 +129,27 @@ Example:
 }
 ```
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td><code>type</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Defaults to:</strong> <code>none</code></p>
-      <p><strong>Allowed values:</strong> <code>none</code>, <code>crowdin_app</code>, <code>crowdin_agent</code></p>
-      <p><strong>Description:</strong> The type of authentication to use.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>clientId</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> OAuth client id for authorization via the <code>crowdin_app</code> type.</p>
-    </td>
-  </tr>
-  </tbody>
-</table>
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `string` | The type of authentication to use: `none` (the default), `crowdin_app`, or `crowdin_agent`. |
+| `clientId` | `string` | OAuth client id for authorization via the `crowdin_app` type. |
 
 ## Modules
 
-Modules are how apps extend Crowdin and interact with it. Using modules your app can do the following things:
+Modules are how an app extends Crowdin. Each type declares where the app appears in the interface or what it processes:
 
-* Extend the Crowdin UI.
-* Create integrations with external services.
-* Add support for new custom file formats.
-* Customize processing for supported file formats.
+* **UI modules**: Panels, dashboards, menus, and dialogs inside Crowdin.
+* **AI modules**: Custom AI providers, prompt providers, and processors for AI requests.
+* **File processing modules**: Custom file formats, and processing before or after import and export.
+* **Other modules**: Custom machine translation engines, webhooks, workflow steps, QA checks, and spellcheckers.
 
 <ReadMore>
-  Read more about [UI Modules](/developer/crowdin-apps-modules-ui/) and [File Processing Modules](/developer/crowdin-apps-modules-file-processing/).
+  Read more about [UI Modules](/developer/crowdin-apps-modules-ui/), [AI Modules](/developer/crowdin-apps-modules-ai/), and [File Processing Modules](/developer/crowdin-apps-modules-file-processing/).
 </ReadMore>
 
 ## Events
 
-Allow an app to register callbacks for events that occur in the workspace. When an event is fired, a POST request will be made to the appropriate URL registered for the event. The installed callback is an integral part of the installation process of an app, whereas the remaining events are essentially webhooks. Each property within this object is a URL relative to the app's base URL.
+A self-hosted app registers callbacks for events that happen in the workspace. Each property in this object is a URL relative to the app's `baseUrl`, and Crowdin sends a POST request to it when the event fires. The `installed` callback is part of the installation itself, and the rest behave like webhooks.
 
 Example:
 
@@ -252,35 +162,14 @@ Example:
 }
 ```
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td><code>installed</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The event that is sent to an app after a user installed the app in Crowdin.</p>
-      <p>This event is required if you use <code>crowdin_app</code> or <code>crowdin_agent</code>. Read more about [Authentication](#authentication).</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>uninstall</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The event that is sent to an app before the app uninstallation from Crowdin.</p>
-    </td>
-  </tr>
-  </tbody>
-</table>
+| Event | Type | Description |
+|-------|------|-------------|
+| `installed` | `string` | Sent to the app after a user installs it in Crowdin. Required with the `crowdin_app` and `crowdin_agent` [authentication](#authentication) types. |
+| `uninstall` | `string` | Sent to the app before it is uninstalled from Crowdin. |
 
 ### Installed Event Payload
 
-The Installed event is sent from Crowdin to the remote app when a user installs the app in Crowdin. The Installed event contains the information about the Crowdin workspace or profile the Crowdin App was installed to, the information about the app itself, as well as the credentials to fetch an API token.
+Crowdin sends the `installed` event to the app when a user installs it. The payload describes the workspace or profile the app was installed to, the app itself, and the credentials the app needs to fetch an API token.
 
 <ReadMore>
   Read more about [Installed Event Flow](/developer/crowdin-apps-installation/#installed-event-communication-flow).
@@ -314,80 +203,20 @@ Payload example:
 
 Properties:
 
-<table>
-  <colgroup>
-    <col width="20%" />
-    <col width="80%" />
-  </colgroup>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td><code>appId</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The identifier of the app that is declared in the app descriptor file.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>appSecret</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The unique secret used for authorization of your Crowdin app.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>clientId</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The OAuth client identifier that is declared in the app descriptor file.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>userId</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>integer</code></p>
-      <p><strong>Description:</strong> The numeric identifier of the user that installed the app in Crowdin Enterprise.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>organizationId</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>integer</code></p>
-      <p><strong>Description:</strong> The numeric identifier of the organization the app was installed to.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>domain</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The name of the organization in Crowdin Enterprise the app was installed to. For Crowdin the domain value is always null</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>baseUrl</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The `baseUrl` of the organization in Crowdin Enterprise the app was installed to. For Crowdin the `baseUrl` value is always `https://crowdin.com`</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>agentId</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>integer</code></p>
-      <p><strong>Description:</strong> The numeric identifier of the agent user created for the app. Sent only for apps with the <code>crowdin_agent</code> authentication type.</p>
-    </td>
-  </tr>
-  </tbody>
-</table>
+| Field | Type | Description |
+|-------|------|-------------|
+| `appId` | `string` | The identifier of the app that is declared in the app descriptor file. |
+| `appSecret` | `string` | The unique secret used for authorization of your Crowdin app. |
+| `clientId` | `string` | The OAuth client identifier that is declared in the app descriptor file. |
+| `userId` | `integer` | The numeric identifier of the user that installed the app. |
+| `organizationId` | `integer` | The numeric identifier of the organization the app was installed to. |
+| `domain` | `string` | The name of the organization in Crowdin Enterprise the app was installed to. In Crowdin the value is always `null`. |
+| `baseUrl` | `string` | The `baseUrl` of the organization in Crowdin Enterprise the app was installed to. In Crowdin the value is always `https://crowdin.com`. |
+| `agentId` | `integer` | The numeric identifier of the agent user created for the app. Sent only for apps with the `crowdin_agent` authentication type. |
 
 ### Uninstall Event Payload
 
-The uninstall event is sent from Crowdin Enterprise to the remote Crowdin app when a user uninstalls the app from Crowdin Enterprise. The Uninstall event, like the install event, contains the information about the Crowdin workspace or account the Crowdin App was installed to, and the information about the app itself. After receiving the uninstall event, it's necessary to find and remove all of the data related to the Crowdin workspace or account the app is removed from.
+Crowdin sends the `uninstall` event to the app before the app is removed. Like the `installed` event, the payload describes the workspace or account the app was installed to and the app itself. Use it to remove the data you stored for that workspace or account.
 
 Payload example:
 
@@ -413,48 +242,10 @@ Payload example:
 
 Properties:
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td><code>appId</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The identifier of the app that is declared in the app descriptor file.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>clientId</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The OAuth client identifier that is declared in the app descriptor file.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>organizationId</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>integer</code></p>
-      <p><strong>Description:</strong> The numeric identifier of the organization the app uninstalled from.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>domain</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The name of the organization in Crowdin Enterprise the app uninstalled from. For Crowdin the domain value is always null</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>baseUrl</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The baseUrl of the organization in Crowdin Enterprise the app uninstalled from. For Crowdin the `baseUrl` value is always `https://crowdin.com`</p>
-    </td>
-  </tr>
-  </tbody>
-</table>
+| Field | Type | Description |
+|-------|------|-------------|
+| `appId` | `string` | The identifier of the app that is declared in the app descriptor file. |
+| `clientId` | `string` | The OAuth client identifier that is declared in the app descriptor file. |
+| `organizationId` | `integer` | The numeric identifier of the organization the app was uninstalled from. |
+| `domain` | `string` | The name of the organization in Crowdin Enterprise the app was uninstalled from. In Crowdin the value is always `null`. |
+| `baseUrl` | `string` | The `baseUrl` of the organization in Crowdin Enterprise the app was uninstalled from. In Crowdin the value is always `https://crowdin.com`. |

--- a/src/content/docs/developer/crowdin-apps/apps-js.mdx
+++ b/src/content/docs/developer/crowdin-apps/apps-js.mdx
@@ -11,6 +11,10 @@ The Crowdin Apps JS is a JavaScript library that enables communication between y
 
 This library solves that problem by providing a secure cross-window messaging (`postMessage()`) bridge. After including the library, you will have access to a global **`AP`** (App Project) object. This object is your single entry point for calling methods (like `AP.getContext()`) and subscribing to events (like `AP.events.on()`).
 
+<Aside>
+  Serverless apps reach these methods through the Crowdin Serverless Apps SDK, which wraps this library. In a self-hosted app, the page you serve calls `AP` directly.
+</Aside>
+
 ## Getting Started
 
 To use the `AP` object, you must include the `iframe.js` script in the `<head>` of your app's HTML page.

--- a/src/content/docs/developer/crowdin-apps/crowdin-apps-sdk.mdx
+++ b/src/content/docs/developer/crowdin-apps/crowdin-apps-sdk.mdx
@@ -26,6 +26,8 @@ Install the package:
 npm install @crowdin/app-project-module
 ```
 
+For the app's own interface, build it from [Crowdin UI Registry](https://github.com/crowdin/ui-registry), a shadcn registry that serves Crowdin's design tokens and components.
+
 Apps built with the Crowdin Apps SDK can be hosted anywhere that runs Node.js (for example, Vercel, AWS Lambda, or Cloudflare Workers).
 
 <LinkCard

--- a/src/content/docs/developer/crowdin-apps/installation.mdx
+++ b/src/content/docs/developer/crowdin-apps/installation.mdx
@@ -110,6 +110,8 @@ Project access options:
 
 ## Installed Event Communication Flow
 
+This flow applies to self-hosted apps, which register the `installed` event in their app descriptor.
+
 When a Crowdin App is installed in the Account Settings, an authorization flow takes place, during which Crowdin and the Crowdin App exchange the authorization data (the authorization code is exchanged for an access token). The following illustration shows the events in this process.
 
 <Image src={communicationFlow} alt="Communication between Crowdin and Crowdin App" />

--- a/src/content/docs/developer/crowdin-apps/publishing/releasing.mdx
+++ b/src/content/docs/developer/crowdin-apps/publishing/releasing.mdx
@@ -1,57 +1,68 @@
 ---
 title: Releasing Crowdin Apps
-description: Learn how to release your Crowdin App to make it accessible to the users
+description: Release your app and publish it on the Crowdin Store
 slug: developer/crowdin-apps-releasing
 sidebar:
   order: 1
 ---
 
 import { Aside, Badge } from '@astrojs/starlight/components';
+import ReadMore from '~/components/ReadMore.astro';
 
-Once the development phase of your Crowdin App is complete, you should publish it to make it accessible to the users and customers.
+When your app is ready, you publish it so that other people can install and use it. What that takes depends on where the app runs.
 
-The release process consists of the following stages:
+## Releasing Self-Hosted Apps
+
+A self-hosted app goes through two stages:
 
 * Setting up and deploying the production environment
-* Publishing your Crowdin App to the [Crowdin Store](https://store.crowdin.com/)
+* Distributing it on the [Crowdin Store](https://store.crowdin.com/)
 
 ### Setting up the Production Environment
 
-When preparing your Crowdin App to release, ensure that it has both the production and development environments. There are many benefits of having separate environments, but the main ones are the following:
+Before releasing, set up separate production and development environments, for two reasons:
 
-* **Stability** &ndash; Having multiple environments reduces or eliminates downtime and thus saves the app from losing customers. It will also prevent incidents of loss or deletion of production data.
-* **Security** &ndash; The separation of environments will restrict access to the customers' data for people who shouldn't have such access.
+* **Stability**: You test changes without risking downtime or the loss of production data.
+* **Security**: Only the people who need customer data have access to it.
 
-Crowdin App must use individual OAuth clients, databases, and other credentials between environments.
+Each environment needs its own OAuth client, database, and credentials.
 
 <Aside>
-  If you design your Crowdin App to be used in both Crowdin and Crowdin Enterprise, [Contact Support Team](https://crowdin.com/contacts), and we will make your OAuth client global for Crowdin and Crowdin Enterprise so that you won't need to create separate OAuth clients for each one.
+  If your app runs in both Crowdin and Crowdin Enterprise, [Contact Support Team](https://crowdin.com/contacts) and we will make your OAuth client global, so you do not need a separate client for each.
 </Aside>
 
 ### Deploying the Crowdin App
 
-When the Crowdin App is ready to be used, you need to host it online to make it accessible to the users. You can choose any preferred platform to your liking. The only requirement is that the platform must be reliable.
+A self-hosted app runs on infrastructure you control, so you can host it anywhere that serves it over HTTPS. Crowdin reaches the app at the `baseUrl` in its app descriptor, so that URL must stay stable once the app is installed.
 
-Below you can see the list of platforms that can be used for deploying:
+Apps built with the Crowdin Apps SDK deploy like any other Node.js application. The SDK documentation covers the platforms it supports.
 
-* **Vercel** - provides the developer experience and infrastructure to build, scale, and secure a faster, more personalized web. Read more about [Getting Started](https://vercel.com/docs) and [Deployment](https://vercel.com/docs/platform/deployments).
-
-* **Heroku** - a container-based cloud Platform as a Service (PaaS). Read more about [Getting Started Guide on Heroku](https://devcenter.heroku.com/start) and [Deployment](https://devcenter.heroku.com/categories/deployment).
-
-* **DigitalOcean** - a cloud computing vendor that offers an infrastructure as a service (IaaS) platform for software developers. Read more about [Getting Started](https://docs.digitalocean.com/products/app-platform/how-to/#getting-started) and [Dev Guide](https://docs.digitalocean.com/products/app-platform/languages-frameworks/).
-
-* **Amazon Web Services** - an online platform that provides scalable and cost-effective cloud computing solutions.
-
-* **Google Cloud** -  a platform offering scalable cloud computing services, data analytics, and tools for building and managing applications.
+<ReadMore>
+  Read more about [deploying an app built with the Crowdin Apps SDK](https://crowdin.github.io/app-project-module/deployment/).
+</ReadMore>
 
 #### Hosting Your Crowdin App on Crowdin Servers
 
-All developers who create their own Crowdin Apps have the opportunity to host their apps on the Crowdin servers. To take advantage of this option, app developers are required to submit their app's source code to Crowdin for review and deployment. Our team will review the source code, and once approved, the app will be hosted by Crowdin.
+Crowdin can also host a self-hosted app for you. This is a separate arrangement from serverless apps, which run on Crowdin infrastructure by design. Submit the app's source code, and once our team reviews and approves it, Crowdin hosts the app.
 
-Each app hosting arrangement comes with custom and personalized agreements tailored specifically to the app. Additionally, apps hosted by Crowdin receive a special <Badge text="Verified by Crowdin" variant="success" /> badge, instilling confidence in potential app users and increasing the likelihood of installation and usage.
+Each hosting arrangement comes with its own agreement. Apps hosted by Crowdin also carry a <Badge text="Verified by Crowdin" variant="success" /> badge.
 
-[Contact Support Team]( https://crowdin.com/contacts), and we will be happy to provide you with more information on the matter.
+[Contact Support Team](https://crowdin.com/contacts) for details.
 
-### Distributing the Crowdin App
+## Releasing Serverless Apps
 
-Once you’re ready to share your Crowdin App with users, [Contact Support Team]( https://crowdin.com/contacts) to provide you with a developer account on [Crowdin Store](https://store.crowdin.com). The developer account lets you publish Crowdin Apps on the Crowdin Store and view different statistics such as the number of installations, application rating, etc.
+A serverless app has no infrastructure of your own to prepare. The Serverless Apps SDK CLI builds the app and publishes the bundle, and Crowdin serves it from then on. While you work on the app, the CLI points Crowdin at a local server instead, so the same modules run against your machine.
+
+Publishing installs the app in your own account. To share it with other Crowdin users, submit it to the Crowdin Store.
+
+<ReadMore>
+  Read more about the [Serverless Apps SDK](/developer/crowdin-apps-serverless/).
+</ReadMore>
+
+## Distributing on the Crowdin Store
+
+To publish on the [Crowdin Store](https://store.crowdin.com), [Contact Support Team](https://crowdin.com/contacts) for a developer account. The account lets you publish apps and see statistics such as the number of installations and the app rating.
+
+<ReadMore>
+  Read more about [Publishing Your App](/developer/crowdin-apps-publishing/).
+</ReadMore>

--- a/src/content/docs/developer/crowdin-apps/security.mdx
+++ b/src/content/docs/developer/crowdin-apps/security.mdx
@@ -1,6 +1,6 @@
 ---
-title: Verifying Requests from Crowdin
-description: Confirm that a request to your app came from Crowdin
+title: Security for Crowdin Apps
+description: Ensure the high level of security for Crowdin apps
 slug: developer/crowdin-apps-security
 ---
 
@@ -22,11 +22,33 @@ Crowdin opens a module page with the token and its context in the query string:
 https://example.com/app-module?jwtToken=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJCcjRhMmhwUW……MX0.yt-lbv3Z8JyIGX4jG405mjZvX8lwc1q0EfWdTtm9GCc&origin=https://{domain}.crowdin.com&clientId=your-client-id
 ```
 
-| Parameter  | Type           | Description                                              |
-|------------|----------------|----------------------------------------------------------|
-| `jwtToken` | `string`       | JWT token used for authorization.                        |
-| `origin`   | `string (url)` | Host used for opening a module page.                     |
-| `clientId` | `string`       | The ID of the OAuth Client used for authorization.       |
+Query parameters:
+
+<table>
+  <tbody>
+  <tr>
+    <td><code>jwtToken</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code></p>
+      <p><strong>Description:</strong> JWT token used for authorization.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>origin</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string (url)</code></p>
+      <p><strong>Description:</strong> Host used for opening a module page.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>clientId</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code></p>
+      <p><strong>Description:</strong> The ID of the OAuth Client used for authorization.</p>
+    </td>
+  </tr>
+  </tbody>
+</table>
 
 The token is signed with the OAuth Client Secret, which only Crowdin and your app know, so a valid signature is proof of where the request came from. Verify the signature and the expiry of every token your app receives, for example in a middleware that runs before the rest of your code. Any of the [existing libraries](https://jwt.io/) does it for you.
 
@@ -43,11 +65,51 @@ The token is signed with the OAuth Client Secret, which only Crowdin and your ap
 }
 ```
 
-| Field     | Type          | Description                                                                                              |
-|-----------|---------------|----------------------------------------------------------------------------------------------------------|
-| `aud`     | `string`      | ID of the OAuth Client that issued the token.                                                            |
-| `sub`     | `string`      | Identifier of the user that is making a request to the Crowdin app.                                      |
-| `domain`  | <code class="whitespace-nowrap">string&#124;null</code> | The organization the app is accessed from. Always present, and always `null` in Crowdin.                  |
-| `context` | `object`      | The environment where the module is opened, such as the project, the locale, and the user's timezone.    |
-| `iat`     | `integer`     | Identifies the issue time of the token.                                                                  |
-| `exp`     | `integer`     | Identifies the expiration time of the token.                                                             |
+Properties:
+
+<table>
+  <tbody>
+  <tr>
+    <td><code>aud</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code></p>
+      <p><strong>Description:</strong> ID of the OAuth Client that issued the token.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>sub</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string</code></p>
+      <p><strong>Description:</strong> Identifier of the user that is making a request to the Crowdin app.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>domain</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>string|null</code></p>
+      <p><strong>Description:</strong> The organization the app is accessed from. Always present, and always <code>null</code> in Crowdin.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code class="whitespace-nowrap">context</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>object</code></p>
+      <p><strong>Description:</strong> The environment where the module is opened, such as the project, the locale, and the user's timezone.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>iat</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>integer</code></p>
+      <p><strong>Description:</strong> Identifies the issue time of the token.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><code>exp</code></td>
+    <td>
+      <p><strong>Type:</strong> <code>integer</code></p>
+      <p><strong>Description:</strong> Identifies the expiration time of the token.</p>
+    </td>
+  </tr>
+  </tbody>
+</table>

--- a/src/content/docs/developer/crowdin-apps/security.mdx
+++ b/src/content/docs/developer/crowdin-apps/security.mdx
@@ -1,72 +1,36 @@
 ---
-title: Security for Crowdin Apps
-description: Ensure the high level of security for Crowdin apps
+title: Verifying Requests from Crowdin
+description: Confirm that a request to your app came from Crowdin
 slug: developer/crowdin-apps-security
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-To ensure the high level of security for cases when the Crowdin app works with the data from Crowdin (i.e. uses the authorization via `crowdin_app`), we've developed a security mechanism. The main principle of this security mechanism is based on the exchange of the JWT token between Crowdin and the Crowdin app. JWT token is signed with an OAuth Client Secret known only to the two final parties. This way, the Crowdin app can get a confirmation that the page is opened precisely in Crowdin.
+When you build a self-hosted app that works with data from Crowdin, it authenticates with [`crowdin_app`](/developer/crowdin-apps-app-descriptor/#authentication) and receives a signed JWT token with every request Crowdin sends it. Verifying that token is how the app tells a real request from anything else.
+
+Both SDKs handle this for you: the [Crowdin Apps SDK](/developer/crowdin-apps-sdk/) validates the token and extracts the context, and a [serverless app](/developer/crowdin-apps-serverless/) never receives a token at all. What follows is for apps that verify requests themselves, for example one written in another language.
 
 <Aside>
-  Apps with the [Workflow Step Type](/developer/crowdin-apps-module-workflow-step-type/#authentication) module must use the `crowdin_agent` authentication type instead of `crowdin_app`.
+  Apps with the [Workflow Step Type](/developer/crowdin-apps-module-workflow-step-type/#authentication) module use the `crowdin_agent` authentication type instead of `crowdin_app`.
 </Aside>
 
-## Implementation
+## What Crowdin Sends
 
-To implement the authorization and authentication in your Crowdin app, follow these steps:
-
-* Add the authorization via `crowdin_app` to your app descriptor and add the OAuth Client ID that will be used for authorization.
-* Add the callback to your Crowdin app that will handle the [Installed Event](/developer/crowdin-apps-installation/#installed-event-communication-flow).
-* Specify the necessary set of scopes in your app descriptor needed for your Crowdin app. The specified set of scopes shouldn't exceed the scopes specified in the OAuth.
-
-Using the above methods, on each request to the Crowdin app, Crowdin will pass a set of parameters along with a security token, which can be validated by a secret from the OAuth.
-
-Below you can see an example of the URL used by Crowdin to open a module page.
+Crowdin opens a module page with the token and its context in the query string:
 
 ```shell wrap
 https://example.com/app-module?jwtToken=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJCcjRhMmhwUW……MX0.yt-lbv3Z8JyIGX4jG405mjZvX8lwc1q0EfWdTtm9GCc&origin=https://{domain}.crowdin.com&clientId=your-client-id
 ```
 
-Query parameters:
+| Parameter  | Type           | Description                                              |
+|------------|----------------|----------------------------------------------------------|
+| `jwtToken` | `string`       | JWT token used for authorization.                        |
+| `origin`   | `string (url)` | Host used for opening a module page.                     |
+| `clientId` | `string`       | The ID of the OAuth Client used for authorization.       |
 
-<table>
-  <tbody>
-  <tr>
-    <td><code>jwtToken</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> JWT token used for authorization.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>origin</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string (url)</code></p>
-      <p><strong>Description:</strong> Host used for opening a module page.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>clientId</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> The ID of the OAuth Client used for authorization.</p>
-    </td>
-  </tr>
-  </tbody>
-</table>
+The token is signed with the OAuth Client Secret, which only Crowdin and your app know, so a valid signature is proof of where the request came from. Verify the signature and the expiry of every token your app receives, for example in a middleware that runs before the rest of your code. Any of the [existing libraries](https://jwt.io/) does it for you.
 
-The best practice would be adding middleware to the Crowdin app to verify whether each request has a token with a valid signature and expiry. You can use one of the [existing libraries](https://jwt.io/) to validate the authenticity of the token.
-
-## JWT Token Structure
-
-JWT token consists of the following parts:
-
-* Header - contains information about the type of the token and encoding algorithms.
-* Payload - contains additional information about the issue and expiration dates of the token, the information about the token issuer and requestor, and other contextual information.
-* Signature - the part with a signature based on the header and payload.
-
-JWT token payload example:
+## Token Payload
 
 ```json
 {
@@ -79,52 +43,11 @@ JWT token payload example:
 }
 ```
 
-Properties:
-
-<table>
-  <tbody>
-  <tr>
-    <td><code>aud</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> ID of the OAuth Client that issued the token.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>sub</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string</code></p>
-      <p><strong>Description:</strong> Identifier of the user that is making a request to the Crowdin app.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>domain</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>string|null</code></p>
-      <p><strong>Required:</strong> yes</p>
-      <p><strong>Description:</strong> The name of the organization from which the app is accessed. For Crowdin the domain value is always <code>null</code></p>
-    </td>
-  </tr>
-  <tr>
-    <td><code class="whitespace-nowrap">context</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>object</code></p>
-      <p><strong>Description:</strong> The information about the environment where the Crowdin app module is opened (e.g. project, locale, user's timezone, etc.).</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>iat</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>integer</code></p>
-      <p><strong>Description:</strong> Identifies the issue time of the token.</p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>exp</code></td>
-    <td>
-      <p><strong>Type:</strong> <code>integer</code></p>
-      <p><strong>Description:</strong> Identifies the expiration time of the token.</p>
-    </td>
-  </tr>
-  </tbody>
-</table>
+| Field     | Type          | Description                                                                                              |
+|-----------|---------------|----------------------------------------------------------------------------------------------------------|
+| `aud`     | `string`      | ID of the OAuth Client that issued the token.                                                            |
+| `sub`     | `string`      | Identifier of the user that is making a request to the Crowdin app.                                      |
+| `domain`  | <code class="whitespace-nowrap">string&#124;null</code> | The organization the app is accessed from. Always present, and always `null` in Crowdin.                  |
+| `context` | `object`      | The environment where the module is opened, such as the project, the locale, and the user's timezone.    |
+| `iat`     | `integer`     | Identifies the issue time of the token.                                                                  |
+| `exp`     | `integer`     | Identifies the expiration time of the token.                                                             |

--- a/src/content/docs/developer/crowdin-apps/serverless-apps.mdx
+++ b/src/content/docs/developer/crowdin-apps/serverless-apps.mdx
@@ -7,7 +7,7 @@ slug: developer/crowdin-apps-serverless
 import { LinkCard } from '@astrojs/starlight/components';
 import ReadMore from '~/components/ReadMore.astro';
 
-The Crowdin Serverless Apps SDK is a TypeScript toolkit for building apps that run on Crowdin infrastructure. You write the UI and register the modules the app appears in, and the CLI builds, previews, and publishes the bundle. It ships a UI kit styled to match Crowdin, an i18n runtime for the app's own translations, and an API client that calls Crowdin as the person using the app, with no tokens to manage.
+The Crowdin Serverless Apps SDK is a TypeScript toolkit for building apps that run on Crowdin infrastructure. You write the UI and register the modules the app appears in, and the CLI builds, previews, and publishes the bundle. It ships a UI kit built from [Crowdin UI Registry](https://github.com/crowdin/ui-registry), Crowdin's set of shadcn components, an i18n runtime for the app's own translations, and an API client that calls Crowdin as the person using the app, with no tokens to manage.
 
 ## What You Can Build
 

--- a/src/content/docs/developer/security/authorizing-oauth-apps.mdx
+++ b/src/content/docs/developer/security/authorizing-oauth-apps.mdx
@@ -197,7 +197,7 @@ curl -H "Authorization: Bearer ACCESS_TOKEN" https://<organization_domain>.api.c
 </Aside>
 
 <ReadMore>
-  Read more about [Verifying Requests from Crowdin](/developer/crowdin-apps-security/).
+  Read more about [Security for Crowdin Apps](/developer/crowdin-apps-security/).
 </ReadMore>
 
 ## Refresh Token

--- a/src/content/docs/developer/security/authorizing-oauth-apps.mdx
+++ b/src/content/docs/developer/security/authorizing-oauth-apps.mdx
@@ -197,7 +197,7 @@ curl -H "Authorization: Bearer ACCESS_TOKEN" https://<organization_domain>.api.c
 </Aside>
 
 <ReadMore>
-  Read more about [JWT Token Structure](/developer/crowdin-apps-security/).
+  Read more about [Verifying Requests from Crowdin](/developer/crowdin-apps-security/).
 </ReadMore>
 
 ## Refresh Token


### PR DESCRIPTION
- Split Releasing Crowdin Apps into self-hosted, serverless, and Store sections
- Turn Security into a reference and retitle it Verifying Requests from Crowdin
- Rework App Descriptor: examples for both app types, missing fields, all module groups, Markdown tables
- Scope the installed event and Crowdin Apps JS to the app types they apply to
- Point both SDK articles at Crowdin UI Registry